### PR TITLE
Run on MacOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   cargo-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # macos-latest is still on macos-12
+        os: [ubuntu-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain


### PR DESCRIPTION
I'm afraid we will need to wait for https://github.com/docker/setup-buildx-action/issues/233 to be fixed before this can move forward.