### PR TITLE
Use im::hashmap::HashMap everywhere

### DIFF
--- a/vm/src/elf.rs
+++ b/vm/src/elf.rs
@@ -1,9 +1,8 @@
 // Copyright 2023 MOZAK.
 
-use alloc::collections::BTreeMap;
-
 use anyhow::{anyhow, bail, Result};
 use elf::{endian::LittleEndian, file::Class, ElfBytes};
+use im::hashmap::HashMap;
 use itertools::Itertools;
 
 /// A RISC program
@@ -12,11 +11,11 @@ pub struct Program {
     pub entry: u32,
 
     /// The initial memory image
-    pub image: BTreeMap<u32, u8>,
+    pub image: HashMap<u32, u8>,
 }
 
-impl From<BTreeMap<u32, u8>> for Program {
-    fn from(image: BTreeMap<u32, u8>) -> Self {
+impl From<HashMap<u32, u8>> for Program {
+    fn from(image: HashMap<u32, u8>) -> Self {
         Self {
             entry: 0_u32,
             image,
@@ -25,8 +24,8 @@ impl From<BTreeMap<u32, u8>> for Program {
 }
 
 #[cfg(test)]
-impl From<BTreeMap<u32, u32>> for Program {
-    fn from(image: BTreeMap<u32, u32>) -> Self {
+impl From<HashMap<u32, u32>> for Program {
+    fn from(image: HashMap<u32, u32>) -> Self {
         let image = image
             .iter()
             .flat_map(move |(k, v)| {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -257,9 +257,8 @@ impl Vm {
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::BTreeMap;
-
     use anyhow::Result;
+    use im::hashmap::HashMap;
     use test_case::test_case;
 
     use crate::{elf::Program, state::State, vm::Vm};
@@ -304,7 +303,7 @@ mod tests {
         }
     }
 
-    fn create_prog(image: BTreeMap<u32, u32>) -> State {
+    fn create_prog(image: HashMap<u32, u32>) -> State {
         State::from(Program::from(image))
     }
 
@@ -317,7 +316,7 @@ mod tests {
               // add ECALL to halt the program
               (exit_at + 4, 0x0000_0073_u32)];
 
-        let image: BTreeMap<u32, u32> = mem.iter().chain(exit_inst.iter()).copied().collect();
+        let image: HashMap<u32, u32> = mem.iter().chain(exit_inst.iter()).copied().collect();
 
         let state = regs.iter().fold(create_prog(image), |state, (rs, val)| {
             state.set_register_value(*rs, *val)


### PR DESCRIPTION
We didn't use any of the benefits of `alloc::collections::BTreeMap`, so for now we simplify.

Builds on top of https://github.com/0xmozak/mozak-vm/pull/119