### PR TITLE
Disable MacOS tests for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
   cargo-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # TODO(Matthias): restore `macos-latest` to run only on pushes to main or on a schedule.
+        # MacOS minutes are ten times more expensive than Ubuntu minutes, so this single job was
+        # eating 2/3 of our GitHub action spend.
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
[MacOS minutes are ten times more expensive than Ubuntu minutes.](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers)

[In this example job](https://github.com/0xmozak/mozak-vm/actions/runs/5174709369) we spend about 194s (= 4s + 53s + 23s + 26s + 49s + 38s) on Ubuntu and 38s on MacOS.  That's equivalent to 380s on Ubuntu, and thus about 2/3 of our total GitHub Action spend.

I left a TODO to re-enable MacOS tests on pushes to main (or perhaps on a schedule).

Take the 2/3 figure with a grain of salt.  In this [other example job](https://github.com/0xmozak/mozak-vm/actions/runs/5176074143), we spend a lot more time (1m 42s) on MacOS.  I'm too lazy/busy to do a proper statistical analysis.