### PR TITLE
refactor: impl Deref for `Code`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +277,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitfield",
+ "derive_more",
  "elf",
  "env_logger",
  "im",
@@ -432,6 +452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +485,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "sized-chunks"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -17,6 +17,7 @@ bitfield = "0.14.0"
 im = "15.1.0"
 proptest = "1.2.0"
 itertools = "0.10.5"
+derive_more = "0.99.17"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/vm/src/elf.rs
+++ b/vm/src/elf.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use anyhow::{anyhow, bail, Result};
+use derive_more::Deref;
 use elf::{endian::LittleEndian, file::Class, ElfBytes};
 use im::hashmap::HashMap;
 use itertools::Itertools;
@@ -24,7 +25,7 @@ pub struct Program {
     pub code: Code,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deref)]
 pub struct Code(HashMap<u32, Instruction>);
 
 impl Code {


### PR DESCRIPTION
This makes using `Code` as a reference to its inner data more idiomatic and Rusty.

Eg. we can now use `self.get()` instead of having to do `let Code(code) = self;` first. ([example in the Rust book](https://doc.rust-lang.org/book/ch15-02-deref.html#treating-a-type-like-a-reference-by-implementing-the-deref-trait))

With apologies to @bingcicle .