### PR TITLE
Git-ignore some CI/CD junk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+target-tarpaulin/
+cobertura.xml
+**/proptest-regressions/


### PR DESCRIPTION
Our CI/CD produced some junk, which is normally not a problem, but can be a bit annoying when you test run it locally.

Extracted from https://github.com/0xmozak/mozak-vm/pull/159