### PR TITLE
Add pre-commit hook for cargo

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+echo "Running hooks..."
+
+if ! cargo fmt -- --check
+then
+    echo "There are some code style issues."
+    echo "Run cargo fmt first."
+    exit 1
+fi
+
+if ! cargo clippy --all-targets -- -D warnings
+then
+    echo "There are some clippy issues."
+    exit 1
+fi
+
+# Enforce cleaner test suits
+# if ! cargo test
+# then
+#     echo "There are some test issues."
+#     exit 1
+# fi
+
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+init:
+	git config core.hooksPath .githooks
+
+build:
+	cargo build
+
+ci: build
+	cargo fmt --all --check
+	cargo clippy --all-features --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ If you are unfamiliar with the Risc-V instruction set, please have a look at the
 The Mozak VM is built in Rust, so the Rust toolchain is a pre-requisite.
 
 ```bash
-cargo build
+# Initialize necessary properties (like hooks) for the repository
+make init
+
+# Build code
+make build
 ```
 
 # Update official Risc-V tests


### PR DESCRIPTION
This PR adds a `pre-commit` hook for cargo clippy (lint) and fmt. It uses the `Makefile` command to set up versioned hooks. 

Feel free to close this without merging if we don't require it or change it as we like. But, it is always good to enforce `ci` locally. 

Not sure if cargo provides any better management compared to Make.