### PR TITLE
fix: Use `tuple_windows` instead of `tuples`

### DIFF
--- a/circuits/src/utils.rs
+++ b/circuits/src/utils.rs
@@ -24,7 +24,10 @@ where
 /// length.
 #[must_use]
 pub fn pad_trace<F: Field>(mut trace: Vec<Vec<F>>, clk_col: Option<usize>) -> Vec<Vec<F>> {
-    assert!(trace.iter().tuples().all(|(a, b)| a.len() == b.len()));
+    assert!(trace
+        .iter()
+        .tuple_windows()
+        .all(|(a, b)| a.len() == b.len()));
     trace.iter_mut().enumerate().for_each(|(i, col)| {
         if let (Some(padded_len), Some(&last)) = (col.len().checked_next_power_of_two(), col.last())
         {


### PR DESCRIPTION
In this case, we want to check that all elements of a vector are the same.  So we need to check overlapping adjacent pairs, not group the vector into non-overlapping pairs.