### PR TITLE
Improve test coverage

### DIFF
--- a/circuits/src/cpu/stark.rs
+++ b/circuits/src/cpu/stark.rs
@@ -104,6 +104,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         2
     }
 
+    #[no_coverage]
     fn eval_ext_circuit(
         &self,
         _builder: &mut CircuitBuilder<F, D>,

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
+#![feature(no_coverage)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::cargo)]
 

--- a/circuits/src/memory/mod.rs
+++ b/circuits/src/memory/mod.rs
@@ -1,3 +1,4 @@
 pub mod columns;
+#[cfg(any(feature = "test", test))]
 pub mod test_utils;
 pub mod trace;

--- a/circuits/src/stark/prover.rs
+++ b/circuits/src/stark/prover.rs
@@ -70,7 +70,7 @@ mod test {
     #[test]
     fn prove_halt() {
         let record = simple_test(0, &[], &[]);
-        simple_proof_test(&record.executed);
+        simple_proof_test(&record.executed).unwrap();
     }
 
     #[test]
@@ -81,14 +81,14 @@ mod test {
             &[(6, 100), (7, 100)],
         );
         assert_eq!(record.last_state.get_register_value(5), 100 + 100);
-        simple_proof_test(&record.executed);
+        simple_proof_test(&record.executed).unwrap();
     }
 
     #[test]
     fn prove_lui() {
         let record = simple_test(4, &[(0_u32, 0x8000_00b7 /* lui r1, 0x80000 */)], &[]);
         assert_eq!(record.last_state.get_register_value(1), 0x8000_0000);
-        simple_proof_test(&record.executed);
+        simple_proof_test(&record.executed).unwrap();
     }
 
     #[test]
@@ -106,6 +106,25 @@ mod test {
             &[],
         );
         assert_eq!(record.last_state.get_register_value(1), 0xDEAD_BEEF,);
-        simple_proof_test(&record.executed);
+        simple_proof_test(&record.executed).unwrap();
+    }
+
+    #[test]
+    fn prove_beq() {
+        let record = simple_test_code(
+            &[Instruction {
+                op: Op::BEQ,
+                data: Data {
+                    rs1: 0,
+                    rs2: 1,
+                    imm: 42,
+                    ..Data::default()
+                },
+            }],
+            &[],
+            &[(1, 2)],
+        );
+        assert_eq!(record.last_state.get_pc(), 8);
+        simple_proof_test(&record.executed).expect_err("FIXME:test-is-expected-to-fail");
     }
 }

--- a/circuits/src/test_utils.rs
+++ b/circuits/src/test_utils.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use mozak_vm::vm::Row;
 use plonky2::{
     plonk::config::{GenericConfig, PoseidonGoldilocksConfig},
@@ -10,7 +11,8 @@ use crate::stark::prover::prove;
 use crate::stark::verifier::verify_proof;
 
 #[allow(clippy::missing_panics_doc)]
-pub fn simple_proof_test(step_rows: &[Row]) {
+#[allow(clippy::missing_errors_doc)]
+pub fn simple_proof_test(step_rows: &[Row]) -> Result<()> {
     const D: usize = 2;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D>>::F;
@@ -20,7 +22,5 @@ pub fn simple_proof_test(step_rows: &[Row]) {
 
     let mut stark = S::default();
     let all_proof = prove::<F, C, D>(step_rows, &mut stark, &config, &mut TimingTree::default());
-    assert!(all_proof.is_ok());
-    let res = verify_proof(&stark, &all_proof.unwrap(), &config);
-    assert!(res.is_ok());
+    verify_proof(&stark, &all_proof.unwrap(), &config)
 }


### PR DESCRIPTION
1. Add `prove_beq` test 
2. Ignore yet unimplemented function
3. TODO: fix verify proof for `BEQ` instruction later