### PR TITLE
Simplify register handling

### DIFF
--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -28,14 +28,14 @@ pub fn generate_cpu_trace<F: RichField>(step_rows: &[Row]) -> [Vec<F>; cpu_cols:
         trace[cpu_cols::COL_RS1][i] = from_(inst.data.rs1);
         trace[cpu_cols::COL_RS2][i] = from_(inst.data.rs2);
         trace[cpu_cols::COL_RD][i] = from_(inst.data.rd);
-        trace[cpu_cols::COL_OP1_VALUE][i] = from_(s.get_register_value(usize::from(inst.data.rs1)));
-        trace[cpu_cols::COL_OP2_VALUE][i] = from_(s.get_register_value(usize::from(inst.data.rs2)));
+        trace[cpu_cols::COL_OP1_VALUE][i] = from_(s.get_register_value(inst.data.rs1));
+        trace[cpu_cols::COL_OP2_VALUE][i] = from_(s.get_register_value(inst.data.rs2));
         // NOTE: Updated value of DST register is next step.
         trace[cpu_cols::COL_DST_VALUE][i] = from_(*dst_val);
         trace[cpu_cols::COL_IMM_VALUE][i] = from_(inst.data.imm);
         trace[cpu_cols::COL_S_HALT][i] = from_(u32::from(*will_halt));
-        for j in 0..32_usize {
-            trace[cpu_cols::COL_START_REG + j][i] = from_(s.get_register_value(j));
+        for j in 0..32 {
+            trace[cpu_cols::COL_START_REG + j as usize][i] = from_(s.get_register_value(j));
         }
 
         match inst.op {

--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -34,7 +34,7 @@ pub fn filter_memory_trace(mut step_rows: Vec<Row>) -> Vec<Row> {
     step_rows.sort_by_key(|row| {
         let data = row.state.current_instruction().data;
         row.state
-            .get_register_value(data.rs1.into())
+            .get_register_value(data.rs1)
             .wrapping_add(data.imm)
     });
 

--- a/vm/src/test_utils.rs
+++ b/vm/src/test_utils.rs
@@ -15,7 +15,7 @@ fn create_prog(image: HashMap<u32, u32>) -> State {
 pub fn simple_test_code(
     code: &[Instruction],
     mem: &[(u32, u32)],
-    regs: &[(usize, u32)],
+    regs: &[(u8, u32)],
 ) -> ExecutionRecord {
     let _ = env_logger::try_init();
     let code = Code(
@@ -72,7 +72,7 @@ pub fn simple_test_code(
 
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn simple_test(exit_at: u32, mem: &[(u32, u32)], regs: &[(usize, u32)]) -> ExecutionRecord {
+pub fn simple_test(exit_at: u32, mem: &[(u32, u32)], regs: &[(u8, u32)]) -> ExecutionRecord {
     // TODO(Matthias): stick this line into proper common setup?
     let _ = env_logger::try_init();
     let exit_inst =

--- a/vm/tests/riscv_tests.rs
+++ b/vm/tests/riscv_tests.rs
@@ -28,8 +28,8 @@ macro_rules! test_elf {
             let state = step(state)?.last_state;
             // At the end of every test,
             // register a0(x10) is set to 0 before an ECALL if it passes
-            assert_eq!(state.get_register_value(10_usize), 0);
-            assert_eq!(state.get_register_value(17_usize), 93);
+            assert_eq!(state.get_register_value(10), 0);
+            assert_eq!(state.get_register_value(17), 93);
             assert!(state.has_halted());
 
             Ok(())


### PR DESCRIPTION
By addressing registers via `u8`, instead of `usize`.