### PR TITLE
Make memory trace test easier to read

### DIFF
--- a/circuits/src/memory/test_utils.rs
+++ b/circuits/src/memory/test_utils.rs
@@ -1,4 +1,8 @@
-use mozak_vm::test_utils::simple_test;
+use mozak_vm::instruction::{
+    Instruction,
+    Op::{LB, SB},
+};
+use mozak_vm::test_utils::simple_test_code;
 use mozak_vm::vm::{ExecutionRecord, Row};
 
 /// # Panics
@@ -11,33 +15,23 @@ use mozak_vm::vm::{ExecutionRecord, Row};
 /// * The value of register 6 is not 15.
 #[must_use]
 pub fn memory_trace_test_case() -> Vec<Row> {
-    // Store Byte: M[rs1 + imm] = rs2
-    // imm[11:5]  rs2    rs1    funct3  imm[4:0]  opcode
-    // Load Byte: rd = M[rs1 + imm]
-    // imm[11:0]         rs1    funct3  rd        opcode
-    // 0000011    00001  00000  000     00100     0100011   sb r1, 100(r0)
-    // 000001100100      00000  000     00100     0000011   lb r4, 100(r0)
-    // 0000110    00011  00000  000     01000     0100011   sb r3, 200(r0)
-    // 000011001000      00000  000     00110     0000011   lb r6, 200(r0)
-    // 0000011    00010  00000  000     00100     0100011   sb r2, 100(r0)
-    // 000001100100      00000  000     00101     0000011   lb r5, 100(r0)
-    let (exit_at, mem, reg) = (
-        24,
-        [
-            (0_u32, 0b0000_0110_0001_0000_0000_0010_0010_0011),
-            (4_u32, 0b0000_0110_0100_0000_0000_0010_0000_0011),
-            (8_u32, 0b0000_1100_0011_0000_0000_0100_0010_0011),
-            (12_u32, 0b0000_1100_1000_0000_0000_0011_0000_0011),
-            (16_u32, 0b0000_0110_0010_0000_0000_0010_0010_0011),
-            (20_u32, 0b0000_0110_0100_0000_0000_0010_1000_0011),
-        ],
-        [(1, 5), (2, 10), (3, 15)],
-    );
-
+    let new = Instruction::new;
     let ExecutionRecord {
         executed,
         last_state: state,
-    } = simple_test(exit_at, &mem, &reg);
+    } = simple_test_code(
+        &[
+            new(SB, 0, 0, 1, 100),
+            new(LB, 4, 0, 0, 100),
+            new(SB, 0, 0, 3, 200),
+            new(LB, 6, 0, 0, 200),
+            new(SB, 0, 0, 2, 100),
+            new(LB, 5, 0, 0, 100),
+        ],
+        &[],
+        &[(1, 5), (2, 10), (3, 15)],
+    );
+
     assert_eq!(state.load_u8(100), 10);
     assert_eq!(state.get_register_value(4), 5);
     assert_eq!(state.get_register_value(5), 10);

--- a/vm/src/decode.rs
+++ b/vm/src/decode.rs
@@ -66,9 +66,9 @@ pub fn decode_instruction(pc: u32, word: u32) -> Instruction {
         ..Default::default()
     };
     let rtype = Data {
+        rd,
         rs1,
         rs2,
-        rd,
         ..Default::default()
     };
     let itype = Data {
@@ -224,9 +224,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::ADD,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -243,8 +243,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::ADD,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -258,9 +258,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::SLL,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -274,8 +274,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::SLLI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm: shamt.into(),
                 ..Default::default()
             },
@@ -289,9 +289,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::SRL,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -304,9 +304,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::SRA,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -319,9 +319,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::SLT,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -334,8 +334,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::SRAI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -349,8 +349,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::SRLI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -364,8 +364,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::SLTI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -379,8 +379,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::SLTIU,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -394,9 +394,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::SLTU,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -411,9 +411,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::SUB,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -444,8 +444,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::JALR,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -561,9 +561,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::AND,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -577,8 +577,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::ANDI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -593,8 +593,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::XORI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -608,9 +608,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::OR,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -624,8 +624,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::ORI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -690,9 +690,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::MUL,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -705,9 +705,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::MULH,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -720,9 +720,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::MULHSU,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -735,9 +735,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::MULHU,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -752,8 +752,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::LW,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -769,8 +769,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::LH,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -786,8 +786,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::LHU,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -803,8 +803,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::LB,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -820,8 +820,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::LBU,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -867,9 +867,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::DIV,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -882,9 +882,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::DIVU,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -897,9 +897,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::REM,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -912,9 +912,9 @@ mod test {
         let match_ins = Instruction {
             op: Op::REMU,
             data: Data {
+                rd,
                 rs1,
                 rs2,
-                rd,
                 ..Default::default()
             },
         };
@@ -938,8 +938,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::FENCE,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Data::default()
             },
@@ -963,8 +963,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::CSRRS,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -978,8 +978,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::CSRRW,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },
@@ -993,8 +993,8 @@ mod test {
         let match_ins = Instruction {
             op: Op::CSRRWI,
             data: Data {
-                rs1,
                 rd,
+                rs1,
                 imm,
                 ..Default::default()
             },

--- a/vm/src/instruction.rs
+++ b/vm/src/instruction.rs
@@ -1,8 +1,8 @@
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct Data {
+    pub rd: u8,
     pub rs1: u8,
     pub rs2: u8,
-    pub rd: u8,
     pub imm: u32,
 }
 
@@ -66,4 +66,14 @@ pub enum Op {
 pub struct Instruction {
     pub op: Op,
     pub data: Data,
+}
+
+impl Instruction {
+    #[must_use]
+    pub fn new(op: Op, rd: u8, rs1: u8, rs2: u8, imm: u32) -> Self {
+        Instruction {
+            op,
+            data: Data { rd, rs1, rs2, imm },
+        }
+    }
 }


### PR DESCRIPTION
And change struct definition field order for `Instruction::Data` to be more consistent with how people usually write Risc-V assembly.