### PR TITLE
feat: JALR contraints

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -14,7 +14,8 @@ pub(crate) const COL_REGS: Range<usize> = COL_START_REG..COL_START_REG + 32;
 
 pub(crate) const COL_S_ADD: usize = COL_REGS.end;
 pub(crate) const COL_S_SUB: usize = COL_S_ADD + 1;
-pub(crate) const COL_S_BEQ: usize = COL_S_SUB + 1;
+pub(crate) const COL_S_JALR: usize = COL_S_SUB + 1;
+pub(crate) const COL_S_BEQ: usize = COL_S_JALR + 1;
 pub(crate) const COL_S_ECALL: usize = COL_S_BEQ + 1;
 pub(crate) const COL_S_HALT: usize = COL_S_ECALL + 1;
 

--- a/circuits/src/cpu/jalr.rs
+++ b/circuits/src/cpu/jalr.rs
@@ -1,0 +1,161 @@
+use plonky2::field::packed::PackedField;
+use starky::constraint_consumer::ConstraintConsumer;
+
+use super::columns::{
+    COL_DST_VALUE, COL_IMM_VALUE, COL_OP1_VALUE, COL_PC, COL_RD, COL_S_JALR, NUM_CPU_COLS,
+};
+use crate::utils::column_of_xs;
+
+pub(crate) fn constraints<P: PackedField>(
+    lv: &[P; NUM_CPU_COLS],
+    nv: &[P; NUM_CPU_COLS],
+    yield_constr: &mut ConstraintConsumer<P>,
+) {
+    let wrap_at: P = column_of_xs(1 << 32);
+
+    let return_address = lv[COL_PC] + column_of_xs::<P>(4);
+    let wrapped_return_address = return_address - wrap_at;
+
+    // enable-if JALR && RD: aux.dst_val == jmp-inst-pc + 4, wrapped
+    yield_constr.constraint(
+        lv[COL_S_JALR]
+            * lv[COL_RD]
+            * (lv[COL_DST_VALUE] - return_address)
+            * (lv[COL_DST_VALUE] - wrapped_return_address),
+    );
+
+    let jump_address = lv[COL_PC] + lv[COL_IMM_VALUE] + lv[COL_OP1_VALUE];
+    let wrapped_jump_address = jump_address - wrap_at;
+
+    // enable-of JALR
+    yield_constr.constraint_transition(
+        lv[COL_S_JALR] * (nv[COL_PC] - jump_address) * (nv[COL_PC] - wrapped_jump_address),
+    );
+}
+#[cfg(test)]
+#[allow(clippy::cast_possible_wrap)]
+mod test {
+    use mozak_vm::instruction::{Args, Instruction, Op};
+    use mozak_vm::test_utils::simple_test_code;
+    use proptest::prelude::any;
+    use proptest::proptest;
+
+    use crate::test_utils::simple_proof_test;
+    proptest! {
+        #[test]
+        fn prove_jalr_goto_no_rs1_proptest(a in any::<u32>(), b in any::<u32>()) {
+            let record = simple_test_code(
+                &[Instruction {
+                    op: Op::JALR,
+                    args: Args {
+                        rd: 0,
+                        rs1: 0,
+                        imm: 4,
+                        ..Args::default()
+                    },
+                }],
+                &[],
+                &[(0x1,a),(0x2,b)],
+            );
+            assert_eq!(record.last_state.get_pc(), 8);
+            simple_proof_test(&record.executed).unwrap();
+        }
+        #[test]
+        fn prove_jalr_goto_rs1_zero_proptest(a in any::<u32>(), b in any::<u32>()) {
+            let record = simple_test_code(
+                &[Instruction {
+                    op: Op::JALR,
+                    args: Args {
+                        rd: 0,
+                        rs1: 1,
+                        imm: 4,
+                        ..Args::default()
+                    },
+                }],
+                &[],
+                &[(0x1,0),(0x2,a),(0x3,b)],
+            );
+            assert_eq!(record.last_state.get_pc(), 8);
+            simple_proof_test(&record.executed).unwrap();
+        }
+
+        #[test]
+        fn prove_jalr_goto_imm_zero_rs1_not_zero_proptest(a in any::<u32>(), b in any::<u32>()) {
+            let record = simple_test_code(
+                &[Instruction {
+                    op: Op::JALR,
+                    args: Args {
+                        rd: 0,
+                        rs1: 1,
+                        imm: 0,
+                        ..Args::default()
+                    },
+                }],
+                &[],
+                &[(0x1,4),(0x2,a),(0x3,b)],
+            );
+            assert_eq!(record.last_state.get_pc(), 8);
+            simple_proof_test(&record.executed).unwrap();
+        }
+
+        #[test]
+        fn prove_jalr_proptest(a in any::<u32>(), b in any::<u32>()) {
+            let record = simple_test_code(
+                &[Instruction {
+                    op: Op::JALR,
+                    args: Args {
+                        rd: 1,
+                        rs1: 0,
+                        imm: 4,
+                        ..Args::default()
+                    },
+                }],
+                &[],
+                &[(0x1, 0), (0x2,a),(0x3,b)],
+            );
+            assert_eq!(record.last_state.get_pc(), 8);
+            simple_proof_test(&record.executed).unwrap();
+        }
+        /*
+        #[test]
+        fn prove_double_jalr_proptest(a in any::<u32>(), b in any::<u32>()) {
+            let record = simple_test_code(
+                &[
+                    Instruction {
+                        op: Op::JALR,
+                        args: Args {
+                            rd: 1,  // return address in x1 will be pc + 4
+                            rs1: 0,
+                            imm: 4, // jump to next instruction
+                            ..Args::default()
+                        },
+                    },
+                    Instruction {
+                        op: Op::ADD,
+                        args: Args {
+                            rd: 1,  // return address in x1 will be pc + 4
+                            rs1: 0,
+                            imm: 4, // jump to next instruction
+                            ..Args::default()
+                        },
+                    },
+                    Instruction {
+                        op: Op::JALR,
+                        args: Args {
+                            rd: 1,  // return address in x1 will be pc + 4
+                            rs1: 0,
+                            imm: 4, // jump to next instruction
+                            ..Args::default()
+                        },
+                }],
+                &[],
+                &[(0x1, 0), (0x2,a),(0x3,b)],
+            );
+            // assert_eq!(record.last_state.get_register_value(5), a.wrapping_sub(b));
+            assert_eq!(record.last_state.get_pc(), 8);
+            simple_proof_test(&record.executed).unwrap();
+        }
+
+         */
+    }
+}

--- a/circuits/src/cpu/mod.rs
+++ b/circuits/src/cpu/mod.rs
@@ -2,3 +2,4 @@ pub mod add;
 pub mod columns;
 pub mod stark;
 pub mod sub;
+pub mod jalr;

--- a/circuits/src/cpu/stark.rs
+++ b/circuits/src/cpu/stark.rs
@@ -9,10 +9,10 @@ use starky::stark::Stark;
 use starky::vars::{StarkEvaluationTargets, StarkEvaluationVars};
 
 use super::columns::{
-    COL_CLK, COL_PC, COL_RD, COL_REGS, COL_S_ADD, COL_S_BEQ, COL_S_ECALL, COL_S_HALT, COL_S_SUB,
-    NUM_CPU_COLS,
+    COL_CLK, COL_PC, COL_RD, COL_REGS, COL_S_ADD, COL_S_BEQ, COL_S_ECALL, COL_S_HALT, COL_S_JALR,
+    COL_S_SUB, NUM_CPU_COLS,
 };
-use super::{add, sub};
+use super::{add, jalr, sub};
 use crate::utils::{column_of_xs, from_};
 
 #[derive(Copy, Clone, Default)]
@@ -24,7 +24,7 @@ pub struct CpuStark<F, const D: usize> {
 use array_concat::{concat_arrays, concat_arrays_size};
 
 pub const STRAIGHTLINE_OPCODES: [usize; 2] = [COL_S_ADD, COL_S_SUB];
-pub const JUMPING_OPCODES: [usize; 2] = [COL_S_BEQ, COL_S_ECALL];
+pub const JUMPING_OPCODES: [usize; 3] = [COL_S_BEQ, COL_S_ECALL, COL_S_JALR];
 pub const OPCODES: [usize; concat_arrays_size!(STRAIGHTLINE_OPCODES, JUMPING_OPCODES)] =
     concat_arrays!(STRAIGHTLINE_OPCODES, JUMPING_OPCODES);
 
@@ -117,13 +117,16 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
 
         // add constraint
         add::constraints(lv, yield_constr);
+        // sub constraint
         sub::constraints(lv, yield_constr);
+        // jalr constraint
+        jalr::constraints(lv, nv, yield_constr);
 
         // Last row must be HALT
         yield_constr.constraint_last_row(lv[COL_S_HALT] - P::ONES);
     }
 
-    fn constraint_degree(&self) -> usize { 3 }
+    fn constraint_degree(&self) -> usize { 4 }
 
     #[no_coverage]
     fn eval_ext_circuit(

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -30,6 +30,7 @@ pub fn generate_cpu_trace<F: RichField>(step_rows: &[Row]) -> [Vec<F>; cpu_cols:
 
         match inst.op {
             Op::ADD => trace[cpu_cols::COL_S_ADD][i] = F::ONE,
+            Op::JALR => trace[cpu_cols::COL_S_JALR][i] = F::ONE,
             Op::BEQ => trace[cpu_cols::COL_S_BEQ][i] = F::ONE,
             Op::SUB => trace[cpu_cols::COL_S_SUB][i] = F::ONE,
             Op::ECALL => trace[cpu_cols::COL_S_ECALL][i] = F::ONE,

--- a/circuits/src/test_utils.rs
+++ b/circuits/src/test_utils.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use mozak_vm::vm::Row;
+use plonky2::fri::FriConfig;
 use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+use plonky2::util::log2_ceil;
 use plonky2::util::timing::TimingTree;
 use starky::config::StarkConfig;
+use starky::stark::Stark;
 
 use crate::stark::mozak_stark::MozakStark;
 use crate::stark::prover::prove;
@@ -19,7 +22,19 @@ pub fn simple_proof_test(step_rows: &[Row]) -> Result<()> {
     config.fri_config.cap_height = 0;
     config.fri_config.proof_of_work_bits = 0;
     config.security_bits = 1;
-
+    let stark = S::default();
+    let config = StarkConfig {
+        security_bits: 1,
+        num_challenges: 2,
+        fri_config: FriConfig {
+            // Plonky2 says: "Having constraints of degree higher than the rate is not supported
+            // yet." So we automatically set the rate here as required by plonky2.
+            rate_bits: log2_ceil(stark.cpu_stark.constraint_degree()),
+            cap_height: 0,
+            proof_of_work_bits: 0,
+            ..config.fri_config
+        },
+    };
     let mut stark = S::default();
     let all_proof = prove::<F, C, D>(step_rows, &mut stark, &config, &mut TimingTree::default());
     verify_proof(&stark, &all_proof.unwrap(), &config)


### PR DESCRIPTION
Still missing: 
1) return address in `nv [ REG_OFFSET + lv [ COL_RD ] ] = PC + 4` 
2) range-check for `imm` 20 bit value 