### PR TITLE
Sneak bogus trace past `SLTU` constraints

### DIFF
--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -55,6 +55,10 @@ pub fn generate_cpu_trace<F: RichField>(step_rows: &[Row]) -> [Vec<F>; cpu_cols:
                 if check.1 || 0 != check.0 {
                     trace[cpu_cols::COL_SLTU_CHECK][i] = F::ONE;
                 }
+                // F::ONE would also work.
+                let fake_outcome = F::ZERO;
+                trace[cpu_cols::COL_DST_VALUE][i] = fake_outcome;
+                trace[cpu_cols::COL_SLTU_CHECK][i] = fake_outcome;
             }
             #[tarpaulin::skip]
             _ => {}


### PR DESCRIPTION
This is not meant to be merged, only meant to show a proof-of-concept exploit:

We can sneak a bogus trace past the proposed `SLTU` constraints.

Note that the tests `cpu::sltu::test::prove_sltiu_proptest` and `cpu::sltu::test::prove_sltu_proptest` succeed, despite the bogus trace.

Please try to find a similar exploit for https://github.com/0xmozak/mozak-vm/pull/243, if you can.