### PR TITLE
Remove decoding from an execution test

### DIFF
--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -243,6 +243,8 @@ pub fn step(mut last_state: State) -> Result<ExecutionRecord> {
 #[allow(clippy::cast_sign_loss)]
 #[allow(clippy::cast_possible_wrap)]
 mod tests {
+    use proptest::prelude::any;
+    use proptest::proptest;
     use test_case::test_case;
 
     use super::ExecutionRecord;
@@ -772,15 +774,18 @@ mod tests {
         assert_eq!(state.get_register_value(5), 100_u32);
     }
 
-    #[test]
-    fn sb() {
-        // at 0 address instruction SB
-        // SB x5, 1200(x0)
-        let ExecutionRecord {
-            last_state: state, ..
-        } = simple_test(4, &[(0, 0x4a50_0823)], &[(5, 0x0000_00FF)]);
+    proptest! {
+        #[test]
+        fn sb(address_reg in 1_u8..32, source_val in any::<u32>()) {
+            let ExecutionRecord {
+                last_state: state, ..
+            } = simple_test_code(&[Instruction::new(Op::SB, 0, 0, address_reg, 1200)], &[], &[(
+                address_reg,
+                source_val,
+            )]);
 
-        assert_eq!(state.load_u32(1200), 0x0000_00FF);
+            assert_eq!(u32::from(state.load_u8(1200)), source_val & 0xff);
+        }
     }
 
     #[test]


### PR DESCRIPTION
One step in https://github.com/0xmozak/mozak-vm/issues/258