### PR TITLE
Revert "Cancel in-progress actions for PR on new push"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches: [ "main" ]
   pull_request: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
This reverts commit 3e98baced99b407cbd05103b1f07592fdea4a291.

It's causing unwanted cancelling of jobs.  Not just redundant ones.