### PR TITLE
Different target dir for tarpaulin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Run tests for coverage
         # skip-clean is there to make tarpaulin not re-build unnecessarily,
         # so caching dependencies works.
-        run: cargo tarpaulin --skip-clean --engine llvm --locked --workspace --out Xml
+        run: cargo tarpaulin --skip-clean --engine llvm --locked --workspace --out Xml --target-dir target-tarpaulin/
 
       - name: Coverage Comment
         uses: ewjoachim/coverage-comment-action@v1.0.3


### PR DESCRIPTION
Our coverage tool, tarpaulin, runs with different RUSTFLAGS than normal builds. As far as I can tell, self-hosted runners don't clean up the target directory by default.  So we need to explicitly give it a differet target-dir now, so there's no interference with eg `cargo test`.