### PR TITLE
test: lower ProptestConfig from 64 to 4.

### DIFF
--- a/circuits/src/cpu/add.rs
+++ b/circuits/src/cpu/add.rs
@@ -37,7 +37,7 @@ mod test {
     use proptest::prelude::{any, ProptestConfig};
     use proptest::proptest;
     proptest! {
-            #![proptest_config(ProptestConfig::with_cases(64))]
+            #![proptest_config(ProptestConfig::with_cases(4))]
             #[test]
             fn prove_add_proptest(a in any::<u32>(), b in any::<u32>(), rd in 0_u8..32) {
                 let record = simple_test_code(

--- a/circuits/src/cpu/slt.rs
+++ b/circuits/src/cpu/slt.rs
@@ -59,11 +59,12 @@ pub(crate) fn constraints<P: PackedField>(
 mod test {
     use mozak_vm::instruction::{Args, Instruction, Op};
     use mozak_vm::test_utils::simple_test_code;
-    use proptest::prelude::any;
+    use proptest::prelude::{any, ProptestConfig};
     use proptest::proptest;
 
     use crate::test_utils::simple_proof_test;
     proptest! {
+            #![proptest_config(ProptestConfig::with_cases(4))]
             #[test]
             fn prove_slt_proptest(a in any::<u32>(), b in any::<u32>()) {
                 let record = simple_test_code(

--- a/circuits/src/cpu/sub.rs
+++ b/circuits/src/cpu/sub.rs
@@ -25,7 +25,7 @@ mod test {
 
     use crate::test_utils::simple_proof_test;
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(64))]
+        #![proptest_config(ProptestConfig::with_cases(4))]
         #[test]
         fn prove_sub_proptest(a in any::<u32>(), b in any::<u32>()) {
             let record = simple_test_code(


### PR DESCRIPTION
This supports proving with lookups, since proving time increases with lookups.