### PR TITLE
feat(cli): add doc comments to CLI commands

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,9 +26,14 @@ struct Cli {
 
 #[derive(Copy, Clone, Debug, Parser, PartialEq, ValueEnum)]
 enum Command {
+    /// Show build info available to shadow_rs
     BuildInfo,
+    /// Decode a given ELF and prints the program
     Decode,
+    /// Decode and execute a given ELF. Prints the final state of
+    /// the registers
     Run,
+    /// Prove and verify the execution of a given ELF
     Prove,
 }
 


### PR DESCRIPTION
Shows a short snippet when running '--help', eg. `cargo run -- --help`