### PR TITLE
Mul Exploit

### DIFF
--- a/circuits/src/cpu/mul.rs
+++ b/circuits/src/cpu/mul.rs
@@ -33,6 +33,27 @@ mod test {
     use proptest::proptest;
 
     use crate::test_utils::simple_proof_test;
+            #[test]
+            fn prove_mul_vivek() {
+                let a = 5;
+                let b = 4;
+                let rd = 5;
+                let record = simple_test_code(
+                    &[Instruction {
+                        op: Op::MUL,
+                        args: Args {
+                            rd,
+                            rs1: 6,
+                            rs2: 7,
+                            ..Args::default()
+                        },
+                    }],
+                    &[],
+                    &[(6, a), (7, b)],
+                );
+                    assert_eq!(record.executed[1].state.get_register_value(rd), a.wrapping_mul(b));
+                simple_proof_test(&record.executed).unwrap();
+            }
     proptest! {
             #![proptest_config(ProptestConfig::with_cases(4))]
             #[test]

--- a/circuits/src/cpu/stark.rs
+++ b/circuits/src/cpu/stark.rs
@@ -159,15 +159,15 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         // Registers
         r0_always_0(lv, yield_constr);
         only_rd_changes(lv, nv, yield_constr);
-        rd_actually_changes(lv, nv, yield_constr);
+        // rd_actually_changes(lv, nv, yield_constr);
         populate_op1_value(lv, yield_constr);
         populate_op2_value(lv, yield_constr);
 
         // add constraint
-        add::constraints(lv, yield_constr);
-        sub::constraints(lv, yield_constr);
-        slt::constraints(lv, yield_constr);
-        div::constraints(lv, yield_constr);
+        // add::constraints(lv, yield_constr);
+        // sub::constraints(lv, yield_constr);
+        // slt::constraints(lv, yield_constr);
+        // div::constraints(lv, yield_constr);
         mul::constraints(lv, yield_constr);
 
         // Last row must be HALT

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -23,13 +23,15 @@ pub fn generate_cpu_trace<F: RichField>(step_rows: &[Row]) -> [Vec<F>; cpu_cols:
         let op2_value = state.get_register_value(inst.args.rs2);
         trace[cpu_cols::COL_OP1_VALUE][i] = from_(op1_value);
         trace[cpu_cols::COL_OP2_VALUE][i] = from_(op2_value);
-        let mul_high_bits = (u64::from(op1_value) * u64::from(op2_value)) >> 32;
-        trace[cpu_cols::MUL_HIGH_BITS][i] = from_(mul_high_bits);
-        let mul_high_diff = u32::MAX - mul_high_bits as u32;
-        let mul_high_diff_f: F = from_(mul_high_diff);
+        // let mul_high_bits = (u64::from(op1_value) * u64::from(op2_value)) >> 32;
+        let mul_high_bits = from_::<u128, F>(10_u128) / from_(0x10000_0000_u128);
+        trace[cpu_cols::MUL_HIGH_BITS][i] = mul_high_bits;
+        // let mul_high_diff = u32::MAX - mul_high_bits as u32;
+        // let mul_high_diff_f: F = from_(mul_high_diff);
+        let mul_high_diff_f: F = from_::<u128, F>(u128::from(u32::MAX)) - mul_high_bits;
         trace[cpu_cols::MUL_HIGH_DIFF_INV][i] = mul_high_diff_f.try_inverse().unwrap_or_default();
         // NOTE: Updated value of DST register is next step.
-        trace[cpu_cols::COL_DST_VALUE][i] = from_(aux.dst_val);
+        trace[cpu_cols::COL_DST_VALUE][i] = from_(10_u128);
         trace[cpu_cols::COL_IMM_VALUE][i] = from_(inst.args.imm);
         trace[cpu_cols::COL_S_HALT][i] = from_(u32::from(aux.will_halt));
         for j in 0..32 {


### PR DESCRIPTION
Basically my point that, current constraint for MUL only prevents user not to prove a * b == some_value which is not actually a *b , when high_bits are not ZERO. For example here  4 * 5 should be 20 but with high_bits I tried to prove 4 * 5 == 10