### PR TITLE
Include DIVU/REMU/SRL selectors in div.rs constraints without increas…

### DIFF
--- a/circuits/src/cpu/div.rs
+++ b/circuits/src/cpu/div.rs
@@ -48,7 +48,7 @@ pub(crate) fn constraints<P: PackedField>(
     // (Interestingly, this holds even when q == 0.)
     let m = lv[QUOTIENT];
     let r = lv[REMAINDER];
-    yield_constr.constraint(m * q + r - p);
+    yield_constr.constraint((is_divu + is_remu + is_srl) * (m * q + r - p));
 
     // However, that constraint is not enough.
     // For example, a malicious prover could trivially fulfill it via
@@ -67,7 +67,7 @@ pub(crate) fn constraints<P: PackedField>(
     //      with range_check(slack)
 
     let slack = lv[REMAINDER_SLACK];
-    yield_constr.constraint(q * (r + slack + P::ONES - q));
+    yield_constr.constraint((is_divu + is_remu + is_srl) * (q * (r + slack + P::ONES - q)));
 
     // Now we need to deal with division by zero.  The Risc-V spec says:
     //      p / 0 == 0xFFFF_FFFF

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -98,6 +98,15 @@ fn generate_divu_row<F: RichField>(
     state: &State,
     row_idx: usize,
 ) {
+    if !matches!(inst.op, Op::DIVU | Op::REMU | Op::SRL) {
+        // set DIVISOR and DIVISOR_INV to 1 in order to prevent
+        // constraints for division by zero to fail.
+        // The constraints for division zero are not restricted only to DIVU/REMU and
+        // SRL as doing so increases degree of cpu constraints to 4.
+        trace[cpu_cols::DIVISOR][row_idx] = from_(1_u32);
+        trace[cpu_cols::DIVISOR_INV][row_idx] = from_(1_u32);
+        return;
+    }
     let op1 = state.get_register_value(inst.args.rs1);
     let op2 = state.get_register_value(inst.args.rs2) + inst.args.imm;
     let (raw_divisor, shift_amount) = if let Op::SRL = inst.op {


### PR DESCRIPTION
Include DIVU/REMU/SRL opcode selectors `in div.rs` constraints without increasing degree.

For division by zero constraint, it's not possible to include selectors for DIVU/REMU without increasing the degree.  So we set default value such that if instruction is not DIVU/REMU they pass.