### PR TITLE
Rename following columns. Drop _S_ as it is used to indicate selector.

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -58,11 +58,11 @@ pub(crate) const COL_S_ECALL: usize = COL_S_BEQ + 1;
 pub(crate) const COL_S_HALT: usize = COL_S_ECALL + 1;
 pub(crate) const COL_S_RC: usize = COL_S_HALT + 1;
 
-pub(crate) const COL_S_SLT_SIGN1: usize = COL_S_RC + 1;
-pub(crate) const COL_S_SLT_SIGN2: usize = COL_S_SLT_SIGN1 + 1;
-pub(crate) const COL_S_SLT_OP1_VAL_FIXED: usize = COL_S_SLT_SIGN2 + 1;
-pub(crate) const COL_S_SLT_OP2_VAL_FIXED: usize = COL_S_SLT_OP1_VAL_FIXED + 1;
-pub(crate) const COL_CMP_ABS_DIFF: usize = COL_S_SLT_OP2_VAL_FIXED + 1;
+pub(crate) const OP1_SIGN: usize = COL_S_RC + 1;
+pub(crate) const OP2_SIGN: usize = OP1_SIGN + 1;
+pub(crate) const OP1_VAL_FIXED: usize = OP2_SIGN + 1;
+pub(crate) const OP2_VAL_FIXED: usize = OP1_VAL_FIXED + 1;
+pub(crate) const COL_CMP_ABS_DIFF: usize = OP2_VAL_FIXED + 1;
 pub(crate) const COL_CMP_DIFF_INV: usize = COL_CMP_ABS_DIFF + 1;
 pub(crate) const COL_LESS_THAN: usize = COL_CMP_DIFF_INV + 1;
 pub(crate) const BRANCH_EQUAL: usize = COL_LESS_THAN + 1;

--- a/circuits/src/cpu/slt.rs
+++ b/circuits/src/cpu/slt.rs
@@ -4,8 +4,8 @@ use starky::constraint_consumer::ConstraintConsumer;
 
 use super::columns::{
     COL_CMP_ABS_DIFF, COL_CMP_DIFF_INV, COL_DST_VALUE, COL_IMM_VALUE, COL_LESS_THAN, COL_OP1_VALUE,
-    COL_OP2_VALUE, COL_S_SLT, COL_S_SLTU, COL_S_SLT_OP1_VAL_FIXED, COL_S_SLT_OP2_VAL_FIXED,
-    COL_S_SLT_SIGN1, COL_S_SLT_SIGN2, NUM_CPU_COLS,
+    COL_OP2_VALUE, COL_S_SLT, COL_S_SLTU, NUM_CPU_COLS, OP1_SIGN, OP1_VAL_FIXED, OP2_SIGN,
+    OP2_VAL_FIXED,
 };
 
 pub(crate) fn constraints<P: PackedField>(
@@ -22,17 +22,17 @@ pub(crate) fn constraints<P: PackedField>(
     let lt = lv[COL_LESS_THAN];
     yield_constr.constraint(lt * (P::ONES - lt));
 
-    let sign1 = lv[COL_S_SLT_SIGN1];
+    let sign1 = lv[OP1_SIGN];
     yield_constr.constraint(sign1 * (P::ONES - sign1));
-    let sign2 = lv[COL_S_SLT_SIGN2];
+    let sign2 = lv[OP2_SIGN];
     yield_constr.constraint(sign2 * (P::ONES - sign2));
 
     let op1 = lv[COL_OP1_VALUE];
     let op2 = lv[COL_OP2_VALUE] + lv[COL_IMM_VALUE];
     // TODO: range check
-    let op1_fixed = lv[COL_S_SLT_OP1_VAL_FIXED];
+    let op1_fixed = lv[OP1_VAL_FIXED];
     // TODO: range check
-    let op2_fixed = lv[COL_S_SLT_OP2_VAL_FIXED];
+    let op2_fixed = lv[OP2_VAL_FIXED];
 
     yield_constr.constraint(is_sltu * (op1_fixed - op1));
     yield_constr.constraint(is_sltu * (op2_fixed - op2));

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -176,14 +176,14 @@ fn generate_slt_row<F: RichField>(
     let op2 = state.get_register_value(inst.args.rs2) + inst.args.imm;
     let sign1: u32 = (is_signed && (op1 as i32) < 0).into();
     let sign2: u32 = (is_signed && (op2 as i32) < 0).into();
-    trace[cpu_cols::COL_S_SLT_SIGN1][row_idx] = from_u32(sign1);
-    trace[cpu_cols::COL_S_SLT_SIGN2][row_idx] = from_u32(sign2);
+    trace[cpu_cols::OP1_SIGN][row_idx] = from_u32(sign1);
+    trace[cpu_cols::OP2_SIGN][row_idx] = from_u32(sign2);
 
     let sign_adjust = if is_signed { 1 << 31 } else { 0 };
     let op1_fixed = op1.wrapping_add(sign_adjust);
     let op2_fixed = op2.wrapping_add(sign_adjust);
-    trace[cpu_cols::COL_S_SLT_OP1_VAL_FIXED][row_idx] = from_u32(op1_fixed);
-    trace[cpu_cols::COL_S_SLT_OP2_VAL_FIXED][row_idx] = from_u32(op2_fixed);
+    trace[cpu_cols::OP1_VAL_FIXED][row_idx] = from_u32(op1_fixed);
+    trace[cpu_cols::OP2_VAL_FIXED][row_idx] = from_u32(op2_fixed);
     trace[cpu_cols::COL_LESS_THAN][row_idx] = from_u32(u32::from(op1_fixed < op2_fixed));
 
     let abs_diff = if is_signed {


### PR DESCRIPTION
Drop _SLT_ as these columns can be reused for BLT/BLTU , BGE/BGEU. COL_S_SLT_SIGN1
COL_S_SLT_SIGN2
COL_S_SLT_OP1_VAL_FIXED
COL_S_SLT_OP2_VAL_FIXED