### PR TITLE
Run tests on MacOS CI in release mode as well, for speed up

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ./.github/actions/rust
 
       - name: Run tests
-        run: cargo test --locked --all-targets
+        run: cargo test --locked --all-targets --release
 
       - name: Create github issue for failed action
         uses: imjohnbo/issue-bot@v3


### PR DESCRIPTION
See https://github.com/0xmozak/mozak-vm/actions/workflows/macos-ci.yml for how they have gotten slower recently as we added more tests.