### PR TITLE
[wip]: fix(rangecheck): fix rangecheck big trace behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "plonky2",
  "plonky2_maybe_rayon",
  "proptest",
+ "rand",
  "starky",
  "thiserror",
 ]

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -25,6 +25,8 @@ thiserror = "1.0.43"
 mozak-vm = { path = "../vm", features = ["test"] }
 proptest = "1.2.0"
 env_logger = {version = "0.10.0"}
+rand = "0.8.5"
+
 
 [features]
 test = []


### PR DESCRIPTION
_WIP_

closes #365 

As @sai-deng rightly pointed out the test for trace bigger than the size of the table (2^16 - 1) was incorrect. In this attempt I try to manually extend the trace to the next power of 2 to properly test that rangechecks work for bigger table sizes.