### PR TITLE
fix range check constraints

### DIFF
--- a/circuits/src/rangecheck/stark.rs
+++ b/circuits/src/rangecheck/stark.rs
@@ -73,7 +73,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for RangeCheckSta
         yield_constr.constraint_first_row(lv.fixed_range_check_u16);
         yield_constr.constraint_transition(
             (nv.fixed_range_check_u16 - lv.fixed_range_check_u16 - FE::ONE)
-                * (nv.fixed_range_check_u16 - FE::from_canonical_u64(u64::from(u16::MAX))),
+                * (nv.fixed_range_check_u16 - lv.fixed_range_check_u16),
         );
         yield_constr.constraint_last_row(
             lv.fixed_range_check_u16 - FE::from_canonical_u64(u64::from(u16::MAX)),


### PR DESCRIPTION
Fix the case which was erroneously accepted as valid: `[0, 1, 2, ..., u16max, u16max + 1, u16max + 2, ..., u16ma + k, u16max]` for any `k`.