### PR TITLE
Rename test: prove_add -> prove_add_example

### DIFF
--- a/circuits/src/cpu/add.rs
+++ b/circuits/src/cpu/add.rs
@@ -26,7 +26,7 @@ mod tests {
     use crate::stark::mozak_stark::MozakStark;
     use crate::test_utils::ProveAndVerify;
     #[test]
-    fn prove_add() -> Result<()> {
+    fn prove_add_example() -> Result<()> {
         let (program, record) = simple_test_code(
             &[Instruction {
                 op: Op::ADD,


### PR DESCRIPTION
That's mostly just a convenience, so it's easier to execute just this one test without also executing `prove_add_proptest`.