### PR TITLE
VM Documentation Improvement

### DIFF
--- a/vm/README.md
+++ b/vm/README.md
@@ -1,0 +1,9 @@
+# VM sub-crate
+
+This sub-crate contains the logic necessary to:
+- Load the RISC-V _(RISC32I+M)_ program from the ELF file representation
+- Run the RISC-V program and provide its execution trace. It implements all the operations of [
+  _RISC32I+M_](https://github.com/jameslzhu/riscv-card/blob/master/riscv-card.pdf) specification.
+
+The purpose of the sub-crate is to emulate the VM and provide its execution trace, which can be then used inside ZK
+prover to prove code execution. 

--- a/vm/src/state.rs
+++ b/vm/src/state.rs
@@ -30,6 +30,7 @@ impl From<&Program> for State {
     }
 }
 
+/// Auxiliary information about the instruction execution
 #[derive(Debug, Clone, Default)]
 pub struct Aux {
     // This could be an Option<u32>, but given how Risc-V instruction are specified,
@@ -159,6 +160,10 @@ impl State {
     }
 
     /// Load a byte from memory
+    ///
+    /// For now, we decided that we will offer the program the full 4 GiB of
+    /// address space you can get with 32 bits.
+    /// So no u32 address is out of bounds.
     #[must_use]
     pub fn load_u8(&self, addr: u32) -> u8 { self.memory.get(&addr).copied().unwrap_or_default() }
 


### PR DESCRIPTION
Added a `README` and Doc Comments to unclear sections of the `state.rs`:
- `Aux`
- `State.load_u8`