### PR TITLE
refactor: move `pad_trace_with_default` for re-use

### DIFF
--- a/circuits/src/generation/bitwise.rs
+++ b/circuits/src/generation/bitwise.rs
@@ -4,6 +4,7 @@ use plonky2::hash::hash_types::RichField;
 
 use crate::bitwise::columns::{BitwiseColumnsView, XorView};
 use crate::cpu::columns::CpuColumnsView;
+use crate::utils::pad_trace_with_default;
 
 fn filter_bitwise_trace<F: RichField>(
     step_rows: &[CpuColumnsView<F>],
@@ -11,11 +12,6 @@ fn filter_bitwise_trace<F: RichField>(
     step_rows.iter().filter_map(|row| {
         (row.inst.ops.ops_that_use_xor().into_iter().sum::<F>() != F::ZERO).then_some(row.xor)
     })
-}
-
-fn pad_trace_with_default<Row: Default + Clone>(mut trace: Vec<Row>) -> Vec<Row> {
-    trace.resize(trace.len().next_power_of_two(), Row::default());
-    trace
 }
 
 fn to_bits<F: RichField>(val: F) -> [F; u32::BITS as usize] {

--- a/circuits/src/utils.rs
+++ b/circuits/src/utils.rs
@@ -22,4 +22,10 @@ pub fn pad_trace<F: Field>(mut trace: Vec<Vec<F>>) -> Vec<Vec<F>> {
 }
 
 #[must_use]
+pub fn pad_trace_with_default<Row: Default + Clone>(mut trace: Vec<Row>) -> Vec<Row> {
+    trace.resize(trace.len().next_power_of_two(), Row::default());
+    trace
+}
+
+#[must_use]
 pub(crate) fn from_u32<F: Field>(x: u32) -> F { Field::from_noncanonical_u64(x.into()) }


### PR DESCRIPTION
Extracted from https://github.com/0xmozak/mozak-vm/pull/434