### PR TITLE
Use argument passed to exit() so that compiler does not optimize it

### DIFF
--- a/guest-example/main.rs
+++ b/guest-example/main.rs
@@ -33,7 +33,7 @@ pub fn _start() -> ! {
 
 /// Exit syscall
 ///
-/// As per RISCV Calling Convetion a0/a1 (which are actually X10/X11) can be
+/// As per RISC-V Calling Convention a0/a1 (which are actually X10/X11) can be
 /// used as function argument/result.
 #[no_mangle]
 #[inline(never)]


### PR DESCRIPTION
fibonacci() function have to return (u32, u32) pair instead of u64 as in asm!() for risc-v we can't take 64 bit registers directly. So now it splits result into high/low  and then path them to exit()