### PR TITLE
refactor: index based access 'view' to accessor based 'state' structs

### DIFF
--- a/circuits/src/columns_view.rs
+++ b/circuits/src/columns_view.rs
@@ -16,7 +16,7 @@ pub trait NumberOfColumns {
 macro_rules! columns_view_impl {
     ($s: ident) => {
         impl<T> $s<T> {
-            // At the moment we only use `map` InstructionView,
+            // At the moment we only use `map` Instruction,
             // so it's dead code for the other callers of `columns_view_impl`.
             // TODO(Matthias): remove this marker, once we use it for the other structs,
             // too.

--- a/circuits/src/cpu/add.rs
+++ b/circuits/src/cpu/add.rs
@@ -2,10 +2,10 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let wrap_at = P::Scalar::from_noncanonical_u64(1 << 32);

--- a/circuits/src/cpu/beq.rs
+++ b/circuits/src/cpu/beq.rs
@@ -2,17 +2,17 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 /// Constraints for BEQ and BNE.
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
-    nv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
+    nv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let bumped_pc = lv.inst.pc + P::Scalar::from_noncanonical_u64(4);
     let branched_pc = lv.inst.branch_target;
-    // TODO: make diff a function on CpuColumnsView.
+    // TODO: make diff a function on CpuState.
     let diff = lv.op1_value - lv.op2_value;
 
     // if `diff == 0`, then `is_equal != 0`.

--- a/circuits/src/cpu/bitwise.rs
+++ b/circuits/src/cpu/bitwise.rs
@@ -17,7 +17,7 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 use crate::bitwise::columns::XorView;
 
 /// A struct to represent the output of binary operations
@@ -65,7 +65,7 @@ pub(crate) fn xor_gadget<P: PackedField>(xor: &XorView<P>) -> BinaryOp<P> {
 /// Constraints to verify execution of AND, OR and XOR instructions.
 #[allow(clippy::similar_names)]
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let op1 = lv.op1_value;

--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -6,10 +6,10 @@ use crate::bitwise::columns::XorView;
 use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
 use crate::cross_table_lookup::Column;
 
-columns_view_impl!(OpSelectorView);
+columns_view_impl!(OpSelectors);
 #[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
-pub struct OpSelectorView<T> {
+pub struct OpSelectors<T> {
     pub add: T,
     pub sub: T,
     pub xor: T,
@@ -29,14 +29,14 @@ pub struct OpSelectorView<T> {
     pub ecall: T,
 }
 
-columns_view_impl!(InstructionView);
+columns_view_impl!(Instruction);
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
-pub struct InstructionView<T> {
+pub struct Instruction<T> {
     /// The original instruction (+ imm_value) used for program
     /// cross-table-lookup.
     pub pc: T,
 
-    pub ops: OpSelectorView<T>,
+    pub ops: OpSelectors<T>,
     pub rs1_select: [T; 32],
     pub rs2_select: [T; 32],
     pub rd_select: [T; 32],
@@ -44,12 +44,12 @@ pub struct InstructionView<T> {
     pub branch_target: T,
 }
 
-columns_view_impl!(CpuColumnsView);
+columns_view_impl!(CpuState);
 #[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
-pub struct CpuColumnsView<T> {
+pub struct CpuState<T> {
     pub clk: T,
-    pub inst: InstructionView<T>,
+    pub inst: Instruction<T>,
 
     pub halt: T,
 
@@ -85,9 +85,9 @@ pub struct CpuColumnsView<T> {
     pub product_high_diff_inv: T,
 }
 
-make_col_map!(CpuColumnsView);
+make_col_map!(CpuState);
 
-pub const NUM_CPU_COLS: usize = CpuColumnsView::<()>::NUMBER_OF_COLUMNS;
+pub const NUM_CPU_COLS: usize = CpuState::<()>::NUMBER_OF_COLUMNS;
 
 /// Column for a binary filter for our range check in the Mozak
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
@@ -109,7 +109,7 @@ pub fn data_for_bitwise<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.xor)
 #[must_use]
 pub fn filter_for_bitwise<F: Field>() -> Column<F> { Column::many(MAP.inst.ops.ops_that_use_xor()) }
 
-impl<T: Copy> OpSelectorView<T> {
+impl<T: Copy> OpSelectors<T> {
     #[must_use]
     pub fn ops_that_use_xor(&self) -> [T; 5] {
         // TODO: Add SRA, once we implement its constraints.

--- a/circuits/src/cpu/div.rs
+++ b/circuits/src/cpu/div.rs
@@ -3,7 +3,7 @@ use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
 use super::bitwise::and_gadget;
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 /// Constraints for DIVU / REMU / SRL instructions
 ///
@@ -12,7 +12,7 @@ use super::columns::CpuColumnsView;
 ///
 /// TODO: m, r, slack need range-checks.
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let dst = lv.dst_value;

--- a/circuits/src/cpu/ecall.rs
+++ b/circuits/src/cpu/ecall.rs
@@ -2,11 +2,11 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
-    nv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
+    nv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     // At the moment, the only system call we support is 'halt', ie ecall with x17 =

--- a/circuits/src/cpu/jalr.rs
+++ b/circuits/src/cpu/jalr.rs
@@ -2,11 +2,11 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
-    nv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
+    nv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let wrap_at = P::Scalar::from_noncanonical_u64(1 << 32);

--- a/circuits/src/cpu/mul.rs
+++ b/circuits/src/cpu/mul.rs
@@ -3,10 +3,10 @@ use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
 use super::bitwise::and_gadget;
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     // TODO: PRODUCT_LOW_BITS and PRODUCT_HIGH_BITS need range checking.

--- a/circuits/src/cpu/slt.rs
+++ b/circuits/src/cpu/slt.rs
@@ -2,10 +2,10 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let p32 = P::Scalar::from_noncanonical_u64(1 << 32);

--- a/circuits/src/cpu/sub.rs
+++ b/circuits/src/cpu/sub.rs
@@ -2,10 +2,10 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 use starky::constraint_consumer::ConstraintConsumer;
 
-use super::columns::CpuColumnsView;
+use super::columns::CpuState;
 
 pub(crate) fn constraints<P: PackedField>(
-    lv: &CpuColumnsView<P>,
+    lv: &CpuState<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let expected_value = lv.op1_value - lv.op2_value;

--- a/circuits/src/generation/bitshift.rs
+++ b/circuits/src/generation/bitshift.rs
@@ -2,10 +2,10 @@ use itertools::Itertools;
 use plonky2::hash::hash_types::RichField;
 
 use crate::bitshift::columns::BitshiftView;
-use crate::cpu::columns::CpuColumnsView;
+use crate::cpu::columns::CpuState;
 
 fn filter_shift_trace<F: RichField>(
-    cpu_trace: &[CpuColumnsView<F>],
+    cpu_trace: &[CpuState<F>],
 ) -> impl Iterator<Item = u64> + '_ {
     cpu_trace.iter().filter_map(|row| {
         (row.inst.ops.ops_that_shift().into_iter().sum::<F>() != F::ZERO)
@@ -21,7 +21,7 @@ pub fn pad_trace<Row: Copy>(mut trace: Vec<Row>, default: Row) -> Vec<Row> {
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
 pub fn generate_shift_amount_trace<F: RichField>(
-    cpu_trace: &[CpuColumnsView<F>],
+    cpu_trace: &[CpuState<F>],
 ) -> Vec<BitshiftView<F>> {
     pad_trace(
         filter_shift_trace(cpu_trace)

--- a/circuits/src/generation/bitwise.rs
+++ b/circuits/src/generation/bitwise.rs
@@ -3,11 +3,11 @@ use itertools::Itertools;
 use plonky2::hash::hash_types::RichField;
 
 use crate::bitwise::columns::{BitwiseColumnsView, XorView};
-use crate::cpu::columns::CpuColumnsView;
+use crate::cpu::columns::CpuState;
 use crate::utils::pad_trace_with_default;
 
 fn filter_bitwise_trace<F: RichField>(
-    step_rows: &[CpuColumnsView<F>],
+    step_rows: &[CpuState<F>],
 ) -> impl Iterator<Item = XorView<F>> + '_ {
     step_rows.iter().filter_map(|row| {
         (row.inst.ops.ops_that_use_xor().into_iter().sum::<F>() != F::ZERO).then_some(row.xor)
@@ -26,7 +26,7 @@ fn to_bits<F: RichField>(val: F) -> [F; u32::BITS as usize] {
 #[allow(clippy::missing_panics_doc)]
 #[allow(clippy::cast_possible_truncation)]
 pub fn generate_bitwise_trace<F: RichField>(
-    cpu_trace: &[CpuColumnsView<F>],
+    cpu_trace: &[CpuState<F>],
 ) -> Vec<BitwiseColumnsView<F>> {
     pad_trace_with_default(
         filter_bitwise_trace(cpu_trace)

--- a/circuits/src/generation/instruction.rs
+++ b/circuits/src/generation/instruction.rs
@@ -1,10 +1,9 @@
 use mozak_vm::instruction::{Instruction, Op};
+use crate::cpu::columns::Instruction as CInstructions;
 
-use crate::cpu::columns::InstructionView;
-
-impl From<(u32, Instruction)> for InstructionView<u32> {
+impl From<(u32, Instruction)> for CInstructions<u32> {
     fn from((pc, inst): (u32, Instruction)) -> Self {
-        let mut cols: InstructionView<u32> = Self {
+        let mut cols: CInstructions<u32> = Self {
             pc,
             imm_value: inst.args.imm,
             branch_target: inst.args.branch_target,

--- a/circuits/src/generation/rangecheck.rs
+++ b/circuits/src/generation/rangecheck.rs
@@ -1,6 +1,6 @@
 use plonky2::hash::hash_types::RichField;
 
-use crate::cpu::columns::CpuColumnsView;
+use crate::cpu::columns::CpuState;
 use crate::lookup::permute_cols;
 use crate::rangecheck::columns;
 use crate::rangecheck::columns::MAP;
@@ -51,7 +51,7 @@ fn push_rangecheck_row<F: RichField>(
 /// 2. trace width does not match the number of columns.
 #[must_use]
 pub fn generate_rangecheck_trace<F: RichField>(
-    cpu_trace: &[CpuColumnsView<F>],
+    cpu_trace: &[CpuState<F>],
 ) -> [Vec<F>; columns::NUM_RC_COLS] {
     let mut trace: Vec<Vec<F>> = vec![vec![]; columns::NUM_RC_COLS];
 


### PR DESCRIPTION
Changes the naming of the following
- `InstructionView` to `Instruction`
- `CpuColumnView` to `CpuState`
- `OpSelectorView` to `OpSelectors`