### PR TITLE
refactor: internalise `.collect_vec` into `Column::singles`

### DIFF
--- a/circuits/src/bitshift/columns.rs
+++ b/circuits/src/bitshift/columns.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use plonky2::field::types::Field;
 
 use crate::columns_view::{columns_view_impl, make_col_map};
@@ -32,7 +31,7 @@ pub struct BitshiftView<T> {
 
 /// Columns containing data from CPU table.
 #[must_use]
-pub fn data_for_cpu<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.executed).collect_vec() }
+pub fn data_for_cpu<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.executed) }
 
 /// Column containing filter from CPU table.
 #[must_use]

--- a/circuits/src/bitwise/columns.rs
+++ b/circuits/src/bitwise/columns.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use plonky2::field::types::Field;
 
 use crate::columns_view::{columns_view_impl, make_col_map};
@@ -27,7 +26,7 @@ columns_view_impl!(XorView);
 /// stark. [`CpuTable`](crate::cross_table_lookup::CpuTable)
 /// [`BitwiseTable`](crate::cross_table_lookup::BitwiseTable).
 #[must_use]
-pub fn data_for_cpu<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.execution).collect_vec() }
+pub fn data_for_cpu<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.execution) }
 
 /// Column for a binary filter to indicate a lookup from the
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable) in the Mozak

--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use plonky2::field::packed::PackedField;
 use plonky2::field::types::Field;
 
@@ -144,7 +143,7 @@ pub fn data_for_rangecheck<F: Field>() -> Vec<Column<F>> { vec![Column::single(M
 /// Columns containing the data to be matched against XOR Bitwise stark.
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
 #[must_use]
-pub fn data_for_bitwise<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.cpu.xor).collect_vec() }
+pub fn data_for_bitwise<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.cpu.xor) }
 
 /// Column for a binary filter for bitwise instruction in Bitwise stark.
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
@@ -167,9 +166,7 @@ impl<T: Copy> OpSelectorView<T> {
 /// Columns containing the data to be matched against `Bitshift` stark.
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
 #[must_use]
-pub fn data_for_shift_amount<F: Field>() -> Vec<Column<F>> {
-    Column::singles(MAP.cpu.bitshift).collect_vec()
-}
+pub fn data_for_shift_amount<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.cpu.bitshift) }
 
 /// Column for a binary filter for shft instruction in `Bitshift` stark.
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
@@ -194,6 +191,4 @@ pub fn data_for_inst<F: Field>() -> Vec<Column<F>> {
 
 /// Columns containing the data of permuted instructions.
 #[must_use]
-pub fn data_for_permuted_inst<F: Field>() -> Vec<Column<F>> {
-    Column::singles(MAP.permuted.inst).collect_vec()
-}
+pub fn data_for_permuted_inst<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.permuted.inst) }

--- a/circuits/src/cross_table_lookup.rs
+++ b/circuits/src/cross_table_lookup.rs
@@ -200,10 +200,8 @@ impl<F: Field> Column<F> {
         }
     }
 
-    pub fn singles<I: IntoIterator<Item = impl Borrow<usize>>>(
-        cs: I,
-    ) -> impl Iterator<Item = Self> {
-        cs.into_iter().map(|c| Self::single(*c.borrow()))
+    pub fn singles<I: IntoIterator<Item = impl Borrow<usize>>>(cs: I) -> Vec<Self> {
+        cs.into_iter().map(|c| Self::single(*c.borrow())).collect()
     }
 
     #[must_use]
@@ -396,7 +394,6 @@ mod tests {
     use std::ops::Deref;
 
     use anyhow::Result;
-    use itertools::Itertools;
     use plonky2::field::goldilocks_field::GoldilocksField;
     use plonky2::field::polynomial::PolynomialValues;
 
@@ -440,7 +437,7 @@ mod tests {
 
     /// Specify which column(s) to find data related to lookups.
     fn lookup_data<F: Field>(col_indices: &[usize]) -> Vec<Column<F>> {
-        Column::singles(col_indices).collect_vec()
+        Column::singles(col_indices)
     }
 
     /// Specify the column index of the filter column used in lookups.

--- a/circuits/src/program/columns.rs
+++ b/circuits/src/program/columns.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use plonky2::field::types::Field;
 
 use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
@@ -33,4 +32,4 @@ pub struct ProgramColumnsView<T> {
 pub const NUM_PROGRAM_COLS: usize = ProgramColumnsView::<()>::NUMBER_OF_COLUMNS;
 
 #[must_use]
-pub fn data_for_ctl<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.inst).collect_vec() }
+pub fn data_for_ctl<F: Field>() -> Vec<Column<F>> { Column::singles(MAP.inst) }


### PR DESCRIPTION
We only ever use `Column::singles` followed by `.collect_vec()`, so we might as well move it inside the function.

Extracted from https://github.com/0xmozak/mozak-vm/pull/472