### PR TITLE
ci: better, more descript `RUST_VERSION` detection via perl

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get rust version (via python3)
+    - name: Get rust version
       run: |
         cat rust-toolchain.toml | perl -e "
 


### PR DESCRIPTION
Cleaner way to get rust version in GH-Actions. Instead of ugly `cut`, `sed` and pipes, we use `perl` script to fetch and set `RUST_VERSION`.