### PR TITLE
Rename `halt` to `halted`

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -57,7 +57,7 @@ pub struct CpuState<T> {
     pub clk: T,
     pub inst: Instruction<T>,
 
-    pub halt: T,
+    pub halted: T,
 
     pub op1_value: T,
     pub op2_value: T,

--- a/circuits/src/cpu/ecall.rs
+++ b/circuits/src/cpu/ecall.rs
@@ -13,10 +13,10 @@ pub(crate) fn constraints<P: PackedField>(
     // 93. Everything else is invalid.
     yield_constr.constraint(lv.inst.ops.ecall * (lv.regs[17] - P::Scalar::from_canonical_u8(93)));
     // Thus we can equate ecall with halt:
-    yield_constr.constraint(lv.inst.ops.ecall - lv.halt);
+    yield_constr.constraint(lv.inst.ops.ecall - lv.halted);
 
     // 'halt' means: no bumping of pc anymore ever.
-    yield_constr.constraint_transition(lv.halt * (nv.inst.pc - lv.inst.pc));
+    yield_constr.constraint_transition(lv.halted * (nv.inst.pc - lv.inst.pc));
 }
 
 // We are already testing ecall with our coda of every `simple_test_code`.

--- a/circuits/src/cpu/stark.rs
+++ b/circuits/src/cpu/stark.rs
@@ -100,8 +100,8 @@ fn clock_ticks<P: PackedField>(
 ) {
     let clock_diff = nv.clk - lv.clk;
     is_binary_transition(yield_constr, clock_diff);
-    is_binary(yield_constr, lv.halt);
-    yield_constr.constraint_transition(clock_diff + lv.halt - P::ONES);
+    is_binary(yield_constr, lv.halted);
+    yield_constr.constraint_transition(clock_diff + lv.halted - P::ONES);
 }
 
 /// Register 0 is always 0
@@ -228,7 +228,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         // Clock starts at 0
         yield_constr.constraint_first_row(lv.clk);
         // Last row must be HALT
-        yield_constr.constraint_last_row(lv.halt - P::ONES);
+        yield_constr.constraint_last_row(lv.halted - P::ONES);
     }
 
     fn constraint_degree(&self) -> usize { 3 }

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -49,7 +49,7 @@ pub fn generate_cpu_trace<F: RichField>(program: &Program, step_rows: &[Row]) ->
             op2_value: from_u32(aux.op2),
             // NOTE: Updated value of DST register is next step.
             dst_value: from_u32(aux.dst_val),
-            halt: from_u32(u32::from(aux.will_halt)),
+            halted: from_u32(u32::from(aux.will_halt)),
             // Valid defaults for the powers-of-two gadget.
             // To be overridden by users of the gadget.
             // TODO(Matthias): find a way to make either compiler or runtime complain
@@ -185,7 +185,7 @@ pub fn generate_permuted_inst_trace<F: RichField>(
 ) -> Vec<ProgramColumnsView<F>> {
     let mut cpu_trace: Vec<_> = trace
         .iter()
-        .filter(|row| row.halt == F::ZERO)
+        .filter(|row| row.halted == F::ZERO)
         .map(|row| row.inst)
         .sorted_by_key(|inst| inst.pc.to_noncanonical_u64())
         .scan(None, |previous_pc, inst| {
@@ -238,7 +238,7 @@ mod tests {
                     imm_value: 3,
                     ..Default::default()
                 },
-                halt: 0,
+                halted: 0,
                 ..Default::default()
             },
             CpuState {
@@ -251,7 +251,7 @@ mod tests {
                     imm_value: 2,
                     ..Default::default()
                 },
-                halt: 0,
+                halted: 0,
                 ..Default::default()
             },
             CpuState {
@@ -264,7 +264,7 @@ mod tests {
                     imm_value: 3,
                     ..Default::default()
                 },
-                halt: 0,
+                halted: 0,
                 ..Default::default()
             },
             CpuState {
@@ -277,14 +277,14 @@ mod tests {
                     imm_value: 4,
                     ..Default::default()
                 },
-                halt: 1,
+                halted: 1,
                 ..Default::default()
             },
         ]
         .into_iter()
         .map(|row| CpuState {
             inst: row.inst.map(from_u32),
-            halt: from_u32(row.halt),
+            halted: from_u32(row.halted),
             ..Default::default()
         })
         .collect();

--- a/circuits/src/stark/mozak_stark.rs
+++ b/circuits/src/stark/mozak_stark.rs
@@ -223,11 +223,11 @@ impl<F: Field> Lookups<F> for InnerCpuTable<F> {
         CrossTableLookup::new(
             vec![CpuTable::new(
                 cpu::columns::data_for_inst(),
-                Column::not(cpu::columns::MAP.cpu.halt),
+                Column::not(cpu::columns::MAP.cpu.halted),
             )],
             CpuTable::new(
                 cpu::columns::data_for_permuted_inst(),
-                Column::not(cpu::columns::MAP.cpu.halt),
+                Column::not(cpu::columns::MAP.cpu.halted),
             ),
         )
     }


### PR DESCRIPTION
The rename expresses that we want this column to signify whether the CPU has already 'halted' at the start of that cycle, not whether the CPU is going to halt.

Extracted from https://github.com/0xmozak/mozak-vm/pull/495