### PR TITLE
revert changes to `CpuState::shifted`

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -114,7 +114,7 @@ pub const NUM_CPU_COLS: usize = CpuState::<()>::NUMBER_OF_COLUMNS;
 
 impl<T: PackedField> CpuState<T> {
     #[must_use]
-    pub fn shifted(&self, places: u64) -> T::Scalar { T::Scalar::from_canonical_u64(1 << places) }
+    pub fn shifted(places: u64) -> T::Scalar { T::Scalar::from_canonical_u64(1 << places) }
 
     pub fn op_diff(&self) -> T { self.op1_value - self.op2_value }
 
@@ -128,12 +128,12 @@ impl<T: PackedField> CpuState<T> {
     /// For signed operations: `Field::from_noncanonical_i64(op1 as i32 as i64)`
     ///
     /// So range is `i32::MIN..=u32::MAX`
-    pub fn op1_full_range(&self) -> T { self.op1_value - self.op1_sign_bit * self.shifted(32) }
+    pub fn op1_full_range(&self) -> T { self.op1_value - self.op1_sign_bit * Self::shifted(32) }
 
     /// Value of the second operand, as if converted to i64.
     ///
     /// So range is `i32::MIN..=u32::MAX`
-    pub fn op2_full_range(&self) -> T { self.op2_value - self.op2_sign_bit * self.shifted(32) }
+    pub fn op2_full_range(&self) -> T { self.op2_value - self.op2_sign_bit * Self::shifted(32) }
 
     pub fn signed_diff(&self) -> T { self.op1_full_range() - self.op2_full_range() }
 }

--- a/circuits/src/cpu/stark.rs
+++ b/circuits/src/cpu/stark.rs
@@ -172,7 +172,7 @@ fn populate_op1_value<P: PackedField>(lv: &CpuState<P>, yield_constr: &mut Const
 /// Constraints for values in op2, which is the sum of the value of the second
 /// operand register and the immediate value. This may overflow.
 fn populate_op2_value<P: PackedField>(lv: &CpuState<P>, yield_constr: &mut ConstraintConsumer<P>) {
-    let wrap_at = lv.shifted(32);
+    let wrap_at = CpuState::<P>::shifted(32);
 
     yield_constr.constraint(
         lv.op2_value_overflowing - lv.inst.imm_value


### PR DESCRIPTION
Specifically, remove the need for `self` as an arg, introduced in #394 in commit [e4960d4](https://github.com/0xmozak/mozak-vm/pull/394/commits/e4960d43d5eb0693369a5eb57ffe35544a079fa5)