### PR TITLE
refactor: list jumping opcodes instead

### DIFF
--- a/circuits/src/cpu/stark.rs
+++ b/circuits/src/cpu/stark.rs
@@ -22,24 +22,14 @@ pub struct CpuStark<F, const D: usize> {
     pub _f: PhantomData<F>,
 }
 
-impl<P: Copy + core::ops::Add<Output = P>> OpSelectors<P> {
+impl<P: PackedField> OpSelectors<P> {
     // Note: ecall is only 'jumping' in the sense that a 'halt' does not bump the
     // PC. It sort-of jumps back to itself.
-    fn is_straightline(&self) -> P {
-        self.add
-            + self.sub
-            + self.and
-            + self.or
-            + self.xor
-            + self.divu
-            + self.mul
-            + self.mulhu
-            + self.remu
-            + self.sll
-            + self.slt
-            + self.sltu
-            + self.srl
+    pub fn is_jumping(&self) -> P {
+        self.beq + self.bge + self.bgeu + self.blt + self.bltu + self.bne + self.ecall + self.jalr
     }
+
+    pub fn is_straightline(&self) -> P { P::ONES - self.is_jumping() }
 
     pub fn is_mem_op(&self) -> P { self.sb + self.lbu }
 }


### PR DESCRIPTION
Instead of explicitly listing the straightline opcodes, we list the one that jump instead.  It's easier to remember when you add a jumping opcode that you have to do something special, than the opposite.

Extracted from https://github.com/0xmozak/mozak-vm/pull/510