### PR TITLE
refactor: `padding` to `is_executed`

### DIFF
--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -11,7 +11,7 @@ use crate::memory::trace::{get_memory_inst_addr, get_memory_inst_clk, get_memory
 fn pad_mem_trace<F: RichField>(mut trace: Vec<Memory<F>>) -> Vec<Memory<F>> {
     trace.resize(trace.len().next_power_of_two(), Memory {
         // Some columns need special treatment..
-        padding: F::ONE,
+        is_executed: F::ZERO,
         diff_addr: F::ZERO,
         diff_addr_inv: F::ZERO,
         diff_clk: F::ZERO,
@@ -44,6 +44,7 @@ pub fn generate_memory_trace<F: RichField>(program: &Program, step_rows: &[Row])
         let mem_addr = get_memory_inst_addr(s);
         let mem_diff_addr = mem_addr - trace.last().map_or(F::ZERO, |last| last.addr);
         trace.push(Memory {
+            is_executed: F::ONE,
             addr: mem_addr,
             clk: mem_clk,
             op: get_memory_inst_op(&inst),
@@ -54,7 +55,6 @@ pub fn generate_memory_trace<F: RichField>(program: &Program, step_rows: &[Row])
                 Some(last) if mem_diff_addr == F::ZERO => mem_clk - last.clk,
                 _ => F::ZERO,
             },
-            padding: F::ZERO,
         });
     }
 
@@ -88,15 +88,15 @@ mod tests {
         let inv = inv::<F>;
         #[rustfmt::skip]
         prep_table(vec![
-            // PADDING  ADDR  CLK   OP  VALUE  DIFF_ADDR  DIFF_ADDR_INV  DIFF_CLK
-            [ 0,       100,  0,    sb,  255,    100,     inv(100),              0],
-            [ 0,       100,  1,    lbu, 255,      0,           0,               1],
-            [ 0,       100,  4,    sb,   10,      0,           0,               3],
-            [ 0,       100,  5,    lbu,  10,      0,           0,               1],
-            [ 0,       200,  2,    sb,   15,    100,     inv(100),              0],
-            [ 0,       200,  3,    lbu,  15,      0,           0,               1],
-            [ 1,       200,  3,    lbu,  15,      0,           0,               0],
-            [ 1,       200,  3,    lbu , 15,      0,           0,               0],
+            // is_executed  addr  clk   op  value  diff_addr  diff_addr_inv  diff_clk
+            [  1,            100,  0,    sb,  255,    100,     inv(100),            0],
+            [  1,            100,  1,    lbu, 255,      0,           0,             1],
+            [  1,            100,  4,    sb,   10,      0,           0,             3],
+            [  1,            100,  5,    lbu,  10,      0,           0,             1],
+            [  1,            200,  2,    sb,   15,    100,     inv(100),            0],
+            [  1,            200,  3,    lbu,  15,      0,           0,             1],
+            [  0,            200,  3,    lbu,  15,      0,           0,             0],
+            [  0,            200,  3,    lbu , 15,      0,           0,             0],
         ])
     }
 

--- a/circuits/src/memory/columns.rs
+++ b/circuits/src/memory/columns.rs
@@ -3,8 +3,8 @@ use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
 #[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct Memory<T> {
-    // Indicates if memory is padding.
-    pub padding: T,
+    // Indicates if a row comes from VM execution, or whether it's padding.
+    pub is_executed: T,
 
     // Memory address.
     pub addr: T,

--- a/circuits/src/memory/stark.rs
+++ b/circuits/src/memory/stark.rs
@@ -41,7 +41,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
         yield_constr.constraint_first_row(lv.diff_clk);
 
         // lv.MEM_PADDING is {0, 1}
-        yield_constr.constraint(lv.padding * (lv.padding - P::ONES));
+        yield_constr.constraint(lv.is_executed * (lv.is_executed - P::ONES));
 
         // lv.MEM_OP in {0, 1}
         yield_constr.constraint(lv.op * (lv.op - P::ONES));


### PR DESCRIPTION
In line with what we do for other tables, we rename and flip the interpretation of the 'padding bit' for the memory table.

Extracted from https://github.com/0xmozak/mozak-vm/pull/510