### PR TITLE
Simplify MUL constraints

### DIFF
--- a/circuits/src/cpu/mul.rs
+++ b/circuits/src/cpu/mul.rs
@@ -19,10 +19,7 @@ pub(crate) fn constraints<P: PackedField>(
     let high_limb = lv.product_high_bits;
     let product = low_limb + base * high_limb;
 
-    yield_constr.constraint(
-        (lv.inst.ops.mul + lv.inst.ops.mulhu + lv.inst.ops.sll)
-            * (product - multiplicand * multiplier),
-    );
+    yield_constr.constraint(product - multiplicand * multiplier);
     yield_constr.constraint((lv.inst.ops.mul + lv.inst.ops.mulhu) * (multiplier - lv.op2_value));
     // The following constraints are for SLL.
     {

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -100,9 +100,6 @@ fn generate_conditional_branch_row<F: RichField>(row: &mut CpuState<F>) {
 #[allow(clippy::cast_possible_wrap)]
 #[allow(clippy::similar_names)]
 fn generate_mul_row<F: RichField>(row: &mut CpuState<F>, inst: &Instruction, aux: &Aux) {
-    if !matches!(inst.op, Op::MUL | Op::MULHU | Op::SLL) {
-        return;
-    }
     let multiplier = if let Op::SLL = inst.op {
         let shift_amount = aux.op2 & 0b1_1111;
         let shift_power = 1_u32 << shift_amount;


### PR DESCRIPTION
Generate multiplication related columns always and hence check relevant constraints always.
This helps by not including selectors like is_mul, is_mulhu etc and reduce constraints degree.