### PR TITLE
refactor(bench): refactor bench_simple to reuse function, rename to be more specific

### DIFF
--- a/circuits/benches/simple_prover.rs
+++ b/circuits/benches/simple_prover.rs
@@ -5,7 +5,7 @@ use mozak_circuits::stark::mozak_stark::MozakStark;
 use mozak_circuits::test_utils::ProveAndVerify;
 use mozak_vm::test_utils::simple_test_code;
 
-fn bench_single(c: &mut Criterion) {
+fn bench_prove_verify_all(c: &mut Criterion) {
     let _ = env_logger::builder().try_init();
     let mut group = c.benchmark_group("prove_verify_all");
     group.measurement_time(Duration::new(10, 0));
@@ -21,6 +21,6 @@ fn bench_single(c: &mut Criterion) {
 criterion_group![
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_single
+    targets = bench_prove_verify_all
 ];
 criterion_main!(benches);


### PR DESCRIPTION
This PR contains 2 changes:

- We reuse `prove_and_verify` here, since the bench code is exactly the same.
- We rename `bench_simple()` to something more specific and self evident, that we're proving and verifying all starks via `MozakStark::prove_and_verify`.