### PR TITLE
deps: unpin serde

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -19,9 +19,7 @@ log = "0.4.20"
 mozak-vm = { path = "../vm" }
 plonky2 = "0.1.3"
 plonky2_maybe_rayon = "0.1.0"
-# Pin serde to at most 1.0.171, since >=1.0.172 ships with a pre-compiled binary.
-# See: https://github.com/serde-rs/serde/issues/2538
-serde = { version = "<=1.0.171", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 starky = "0.1.1"
 thiserror = "1.0.44"
 


### PR DESCRIPTION
Reverts commit 9bb636eefe577c88ef1bb7505e3dd6d2bac057a0.

The whole fiasco over shipping precompiled binaries with serde_derive was resolved with a [new release](https://github.com/serde-rs/serde/releases/tag/v1.0.184). See this [PR](https://github.com/serde-rs/serde/pull/2590) as well - seems like the maintainer took active steps to make sure the precompile was phased out after listening to feedback.