### PR TITLE
(do not merge) failing bitshift repro

### DIFF
--- a/circuits/src/bitshift/stark.rs
+++ b/circuits/src/bitshift/stark.rs
@@ -90,6 +90,7 @@ mod tests {
     use starky::stark_testing::test_stark_low_degree;
 
     use super::BitshiftStark;
+    use crate::stark::mozak_stark::MozakStark;
     use crate::test_utils::ProveAndVerify;
 
     const D: usize = 2;
@@ -131,6 +132,7 @@ mod tests {
             );
             prop_assert_eq!(record.executed[0].aux.dst_val, p << (q & 0x1F));
             prop_assert_eq!(record.executed[1].aux.dst_val, p >> (q & 0x1F));
+            MozakStark::prove_and_verify(&program, &record).unwrap();
             BitshiftStark::prove_and_verify(&program, &record).unwrap();
         }
     }


### PR DESCRIPTION
```console
$ MOZAK_STARK_DEBUG=1 cargo test -p mozak-circuits prove_shift_amount
...
Row [0, 1] is present 2 times in the looking tables, but
                    1 times in the looked table.
Looking locations: [(Cpu, 0), (Cpu, 1)].
Looked locations: [(Bitshift, 1)].
thread 'bitshift::stark::tests::prove_shift_amount_proptest' panicked at 'called `Result::unwrap()` on an `Err` value: InconsistentTableRows', circuits/src/cross_table_lookup.rs:409:71
thread 'bitshift::stark::tests::prove_shift_amount_proptest' panicked at 'Test failed: called `Result::unwrap()` on an `Err` value: InconsistentTableRows.
minimal failing input: p = 0, q = 0
	successes: 0
	local rejects: 0
	global rejects: 0
', circuits/src/bitshift/stark.rs:107:5
```