### PR TITLE
chore(tests): prove mozak stark in a smaller test for MemoryStark

### DIFF
--- a/circuits/src/memory/stark.rs
+++ b/circuits/src/memory/stark.rs
@@ -116,10 +116,17 @@ mod tests {
     }
 
     #[test]
+    fn prove_memory_sb_lb_all() -> Result<()> {
+        let (program, executed) = memory_trace_test_case(1);
+        MozakStark::prove_and_verify(&program, &executed)?;
+        Ok(())
+    }
+
+    #[test]
     fn prove_memory_sb_lb() -> Result<()> {
         for repeats in 0..8 {
             let (program, executed) = memory_trace_test_case(repeats);
-            MozakStark::prove_and_verify(&program, &executed)?;
+            MemoryStark::prove_and_verify(&program, &executed)?;
         }
         Ok(())
     }


### PR DESCRIPTION
We were running `MozakStark::prove_and_verify` for all 8 repetitions, which proved to be [slow](https://github.com/0xmozak/mozak-vm/actions/runs/6016240567/job/16319779375#step:4:239). This commit uses the above in a separate test, and uses `MemoryStark::prove_and_verify` for the test with repetitions.