### PR TITLE
fix: add missing `#[repr(C)]` for column definitions

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -55,6 +55,7 @@ pub struct OpSelectors<T> {
 }
 
 columns_view_impl!(Instruction);
+#[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct Instruction<T> {
     /// The original instruction (+ imm_value) used for program

--- a/circuits/src/memoryinit/columns.rs
+++ b/circuits/src/memoryinit/columns.rs
@@ -13,6 +13,7 @@ pub struct MemElement<T> {
 
 columns_view_impl!(MemoryInit);
 make_col_map!(MemoryInit);
+#[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct MemoryInit<T> {
     pub rodata: MemElement<T>,

--- a/circuits/src/program/columns.rs
+++ b/circuits/src/program/columns.rs
@@ -20,6 +20,7 @@ pub struct InstructionRow<T> {
 
 columns_view_impl!(ProgramRom);
 make_col_map!(ProgramRom);
+#[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct ProgramRom<T> {
     pub inst: InstructionRow<T>,


### PR DESCRIPTION
We actually rely on the precise memory layout when we borrow and transmute.  So we need to tell the Rust compiler not to re-order elements.