### PR TITLE
chore: centralise some clippy exceptions

### DIFF
--- a/circuits/src/cross_table_lookup.rs
+++ b/circuits/src/cross_table_lookup.rs
@@ -343,7 +343,6 @@ pub mod ctl_utils {
         }
     }
 
-    #[allow(clippy::missing_errors_doc)]
     pub fn check_single_ctl<F: Field>(
         trace_poly_values: &[Vec<PolynomialValues<F>>],
         ctl: &CrossTableLookup<F>,
@@ -398,7 +397,6 @@ pub mod ctl_utils {
 
         Ok(())
     }
-    #[allow(clippy::missing_panics_doc)]
     pub fn debug_ctl<F: RichField + Extendable<D>, const D: usize>(
         traces_poly_values: &[Vec<PolynomialValues<F>>; NUM_TABLES],
         mozak_stark: &MozakStark<F, D>,

--- a/circuits/src/generation/bitshift.rs
+++ b/circuits/src/generation/bitshift.rs
@@ -17,7 +17,6 @@ pub fn pad_trace<Row: Copy>(mut trace: Vec<Row>, default: Row) -> Vec<Row> {
 }
 
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn generate_shift_amount_trace<F: RichField>(
     cpu_trace: &[CpuState<F>],
 ) -> Vec<BitshiftView<F>> {

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -15,7 +15,6 @@ use crate::stark::utils::transpose_trace;
 use crate::utils::{from_u32, pad_trace_with_last_to_len, sign_extend};
 use crate::xor::columns::XorView;
 
-#[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn generate_cpu_trace_extended<F: RichField>(
     cpu_trace: Vec<CpuState<F>>,
@@ -32,7 +31,6 @@ pub fn generate_cpu_trace_extended<F: RichField>(
     chain!(transpose_trace(cpu_trace), transpose_trace(permuted)).collect()
 }
 
-#[allow(clippy::missing_panics_doc)]
 pub fn generate_cpu_trace<F: RichField>(
     program: &Program,
     record: &ExecutionRecord,

--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -33,7 +33,6 @@ pub fn filter_memory_trace(step_rows: &[Row]) -> Vec<&Row> {
 }
 
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn generate_memory_trace<F: RichField>(program: &Program, step_rows: &[Row]) -> Vec<Memory<F>> {
     let filtered_step_rows = filter_memory_trace(step_rows);
 

--- a/circuits/src/generation/memoryinit.rs
+++ b/circuits/src/generation/memoryinit.rs
@@ -6,7 +6,6 @@ use crate::utils::pad_trace_with_default;
 
 /// Generates a memory init ROM trace
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn generate_memory_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
     pad_trace_with_default(
         program

--- a/circuits/src/generation/mod.rs
+++ b/circuits/src/generation/mod.rs
@@ -68,7 +68,6 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
 }
 
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn transpose_polys<
     F: RichField + Extendable<D> + PackedField,
     const D: usize,
@@ -87,7 +86,6 @@ pub fn transpose_polys<
     .collect_vec()
 }
 
-#[allow(clippy::missing_panics_doc)]
 pub fn debug_traces<F: RichField + Extendable<D>, const D: usize>(
     traces_poly_values: &[Vec<PolynomialValues<F>>; NUM_TABLES],
     mozak_stark: &MozakStark<F, D>,
@@ -154,7 +152,6 @@ pub fn debug_traces<F: RichField + Extendable<D>, const D: usize>(
     .all(|x| x));
 }
 
-#[allow(clippy::missing_panics_doc)]
 pub fn debug_single_trace<F: RichField + Extendable<D>, const D: usize, S: Stark<F, D>>(
     stark: &S,
     trace_rows: &[PolynomialValues<F>],

--- a/circuits/src/generation/program.rs
+++ b/circuits/src/generation/program.rs
@@ -7,7 +7,6 @@ use crate::utils::pad_trace_with_default;
 
 /// Generates a program ROM trace
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn generate_program_rom_trace<F: RichField>(program: &Program) -> Vec<ProgramRom<F>> {
     pad_trace_with_default(
         program

--- a/circuits/src/generation/rangecheck.rs
+++ b/circuits/src/generation/rangecheck.rs
@@ -46,7 +46,6 @@ fn push_rangecheck_row<F: RichField>(
     }
 }
 
-#[allow(clippy::missing_panics_doc)]
 pub fn extract<'a, F: RichField, V>(trace: &[V], looking_table: &Table<F>) -> Vec<F>
 where
     V: Index<usize, Output = F> + 'a, {

--- a/circuits/src/generation/xor.rs
+++ b/circuits/src/generation/xor.rs
@@ -24,7 +24,6 @@ fn to_bits<F: RichField>(val: F) -> [F; u32::BITS as usize] {
 }
 
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 #[allow(clippy::cast_possible_truncation)]
 pub fn generate_xor_trace<F: RichField>(cpu_trace: &[CpuState<F>]) -> Vec<XorColumnsView<F>> {
     pad_trace_with_default({

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -7,6 +7,10 @@
 #![register_tool(tarpaulin)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::cargo)]
+// TODO: When things have settled a bit, and we make a big push to improve docs, we can remove these
+// exceptions:
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
 // FIXME: Remove this, when proptest's macro is updated not to trigger clippy.
 #![allow(clippy::ignored_unit_patterns)]
 

--- a/circuits/src/memory/test_utils.rs
+++ b/circuits/src/memory/test_utils.rs
@@ -4,7 +4,6 @@ use mozak_vm::instruction::{Args, Instruction};
 use mozak_vm::test_utils::simple_test_code;
 use mozak_vm::vm::ExecutionRecord;
 
-#[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn memory_trace_test_case(repeats: usize) -> (Program, ExecutionRecord) {
     let new = Instruction::new;

--- a/circuits/src/stark/prover.rs
+++ b/circuits/src/stark/prover.rs
@@ -37,8 +37,6 @@ use crate::stark::permutation::{
 use crate::stark::poly::compute_quotient_polys;
 use crate::xor::stark::XorStark;
 
-#[allow(clippy::missing_errors_doc)]
-#[allow(clippy::missing_panics_doc)]
 pub fn prove<F, C, const D: usize>(
     program: &Program,
     record: &ExecutionRecord,

--- a/circuits/src/stark/verifier.rs
+++ b/circuits/src/stark/verifier.rs
@@ -23,7 +23,6 @@ use crate::stark::poly::eval_vanishing_poly;
 use crate::stark::proof::{AllProofChallenges, StarkOpeningSet, StarkProof, StarkProofChallenges};
 use crate::xor::stark::XorStark;
 
-#[allow(clippy::missing_errors_doc)]
 pub fn verify_proof<F, C, const D: usize>(
     mozak_stark: MozakStark<F, D>,
     all_proof: AllProof<F, C, D>,

--- a/circuits/src/utils.rs
+++ b/circuits/src/utils.rs
@@ -22,7 +22,6 @@ pub fn pad_trace<F: Field>(mut trace: Vec<Vec<F>>) -> Vec<Vec<F>> {
 }
 
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn pad_trace_with_last_to_len<Row: Default + Clone>(
     mut trace: Vec<Row>,
     len: usize,


### PR DESCRIPTION
At the moment, we don't really care too much about missing docs for errors and panics.  So instead of mentioning that for every function, we can mention it once.