### PR TITLE
opt: decode `SLLI ` as `MUL`

### DIFF
--- a/vm/src/decode.rs
+++ b/vm/src/decode.rs
@@ -149,7 +149,7 @@ pub fn decode_instruction(pc: u32, word: u32) -> Instruction {
         0b001_0011 => match bf.func3() {
             // For Risc-V its ADDI but we handle it as ADD.
             0x0 => (Op::ADD, itype),
-            // For Risc-V its SLLI but we handle it as MUL
+            // For Risc-V it's SLLI, but we handle it as MUL
             0x1 if 0 == itype.imm & !0b1_1111 => (Op::MUL, Args {
                 imm: 1 << itype.imm,
                 ..itype


### PR DESCRIPTION
Replace SLLI with corresponding MUL operation. First part of #601