### PR TITLE
Fix the Exploit in #613

### DIFF
--- a/circuits/src/cpu/div.rs
+++ b/circuits/src/cpu/div.rs
@@ -73,13 +73,12 @@ pub(crate) fn constraints<P: PackedField>(
 
     // Also for DIV operation, dividend and remainder have same sign.
     // If we don't enforce the above, prover can spoof by using the equation
-    //    x = dq + r = d(q + 1) + (r - d), with |r - d| and |r| being made to be less than |d|
-    // So when r != 0, we can just enforce equality of signs.
-    // when r = 0, the above exploit would no longer work, so no need to ensure sign equality
+    //    x = dq + r = d(q + 1) + (r - d), with |r - d| and |r| being made to be
+    // less than |d| So when r != 0, we can just enforce equality of signs.
+    // when r = 0, the above exploit would no longer work, so no need to ensure sign
+    // equality
 
     yield_constr.constraint(remainder_value * (remainder_sign - dividend_sign));
-
-
 
     // Constraints for divisor == 0.  On Risc-V:
     // p / 0 == 0xFFFF_FFFF


### PR DESCRIPTION
Fixed the exploit in #613 by ensuring the sign equality of dividend and remainder

Update: Github's proptest fails at seemingly random input. The proptests worked on my machine though.
               Verified that ` p = 2147483648, q = 4294967295, rd = 28` is indeed failing input to `prove_div_mozak`
               Working on fixing this
Update: the above failing test is fixed in #598. The purpose of the PR is fulfilled anyway. Closing the PR