### PR TITLE
add: `ro_mem` init via `simple_test_code_with_ro_memory(...)`

### DIFF
--- a/runner/src/test_utils.rs
+++ b/runner/src/test_utils.rs
@@ -18,9 +18,11 @@ pub fn state_before_final(e: &ExecutionRecord) -> &State { &e.executed[e.execute
 
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn simple_test_code(
+#[allow(clippy::similar_names)]
+pub fn simple_test_code_with_ro_memory(
     code: &[Instruction],
-    mem: &[(u32, u32)],
+    ro_mem: &[(u32, u32)],
+    rw_mem: &[(u32, u32)],
     regs: &[(u8, u32)],
 ) -> (Program, ExecutionRecord) {
     let _ = env_logger::try_init();
@@ -54,7 +56,8 @@ pub fn simple_test_code(
     );
 
     let program = Program {
-        rw_memory: Data::from(mem.iter().copied().collect::<HashMap<u32, u32>>()),
+        ro_memory: Data::from(ro_mem.iter().copied().collect::<HashMap<u32, u32>>()),
+        rw_memory: Data::from(rw_mem.iter().copied().collect::<HashMap<u32, u32>>()),
         ro_code,
         ..Default::default()
     };
@@ -67,6 +70,16 @@ pub fn simple_test_code(
     let record = step(&program, state).unwrap();
     assert!(record.last_state.has_halted());
     (program, record)
+}
+
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn simple_test_code(
+    code: &[Instruction],
+    rw_mem: &[(u32, u32)],
+    regs: &[(u8, u32)],
+) -> (Program, ExecutionRecord) {
+    simple_test_code_with_ro_memory(code, &[], rw_mem, regs)
 }
 
 #[cfg(any(feature = "test", test))]


### PR DESCRIPTION
Part of larger work undertaken under https://github.com/0xmozak/mozak-vm/pull/602