### PR TITLE
opt: Enable link-time-optimization for release and benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ lto = "thin"
 opt-level = 3
 
 [profile.release]
-lto = "thin"
+lto = "fat"
 
 [patch.crates-io]
 plonky2 = { git = "https://github.com/0xmozak/plonky2.git" }


### PR DESCRIPTION
Benchmarks show about a 5% increase in performance, and we already use `lto="thin"` in our tests anyway.

Update: I tried `lto="fat"` and got another ~6% increase in performance compared to `lto="thin"` at the cost of slightly longer build times.  (Which mostly matter for development and testing, but don't really matter for release and benchmarking.)

To wit, going from `"thin"` to `"fat`" gives:
```
time:   [14.080 s 14.132 s 14.194 s]
change: [-7.3244% -6.5390% -5.8562%] (p = 0.00 < 0.05)
Performance has improved.
```

Or for directly going from current status quo of `"off"` to `"fat"`:
```
time:   [14.159 s 14.210 s 14.265 s]
change: [-12.286% -11.857% -11.389%] (p = 0.00 < 0.05)
Performance has improved.
```