### PR TITLE
refactor(reginit): rename `is_dummy` -> `is_used`, flip boolean values

### DIFF
--- a/circuits/src/generation/registerinit.rs
+++ b/circuits/src/generation/registerinit.rs
@@ -11,7 +11,7 @@ pub fn generate_register_init_trace<F: RichField>() -> Vec<RegisterInit<F>> {
             .map(|i| RegisterInit {
                 reg_addr: F::from_canonical_usize(i),
                 value: F::ZERO,
-                is_used: F::from_bool(i != 0),
+                is_looked_up: F::from_bool(i != 0),
             })
             .collect(),
     )
@@ -32,8 +32,8 @@ mod tests {
         assert_eq!(trace.len(), 32);
         for (i, r) in trace.iter().enumerate().take(32) {
             assert!(match i {
-                0 => r.is_used.is_zero(),
-                _ => r.is_used.is_one(),
+                0 => r.is_looked_up.is_zero(),
+                _ => r.is_looked_up.is_one(),
             });
             assert_eq!(r.reg_addr, F::from_canonical_usize(i));
             assert_eq!(r.value, F::ZERO);

--- a/circuits/src/registerinit/columns.rs
+++ b/circuits/src/registerinit/columns.rs
@@ -19,5 +19,5 @@ pub struct RegisterInit<T> {
     ///
     /// In our design, r0 should always be unused, so it's always 0.
     /// The other registers (r1-r31) should all be 1.
-    pub is_used: T,
+    pub is_looked_up: T,
 }

--- a/circuits/src/registerinit/stark.rs
+++ b/circuits/src/registerinit/stark.rs
@@ -36,8 +36,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for RegisterInitS
         FE: FieldExtension<D2, BaseField = F>,
         P: PackedField<Scalar = FE>, {
         let lv: &RegisterInit<P> = vars.local_values.borrow();
-        // Check: `is_used` is a binary filter column.
-        is_binary(yield_constr, lv.is_used);
+        // Check: `is_looked_up` is a binary filter column.
+        is_binary(yield_constr, lv.is_looked_up);
     }
 
     #[no_coverage]


### PR DESCRIPTION
In the original PR #644 , we use `is_dummy`, and r0 == 1 (other registers == 0).

In this PR, we rename it to `is_used`, and r0 == 0 (other registers == 1).

This makes it convenient for CTL (no need to negate `is_dummy` for filtering against `is_init` in the `RegisterStark`). See: https://github.com/0xmozak/mozak-vm/blob/54563281b83b74ebdb1cee82eac05fc744c9b1bc/circuits/src/registerinit/columns.rs#L25-L29