### PR TITLE
fix(reg): fix initial values of register trace

### DIFF
--- a/circuits/src/generation/register.rs
+++ b/circuits/src/generation/register.rs
@@ -55,9 +55,13 @@ pub fn generate_register_trace<F: RichField>(
     program: &Program,
     record: &ExecutionRecord,
 ) -> Vec<Register<F>> {
-    let ExecutionRecord { executed, last_state } = record;
+    let ExecutionRecord {
+        executed,
+        last_state,
+    } = record;
 
-    let mut trace = init_register_trace(record.executed.first().map_or(last_state, |row| &row.state));
+    let mut trace =
+        init_register_trace(record.executed.first().map_or(last_state, |row| &row.state));
 
     for Row { state, .. } in executed {
         let inst = state.current_instruction(program);


### PR DESCRIPTION
The key fix here is that I didn't include the initial value of the registers in the original PR. This PR fixes that. On the side, also refactored some test setup code to look cleaner.