### PR TITLE
feat(reg): Introduce `diff_augmented_clk` column

### DIFF
--- a/circuits/src/generation/register.rs
+++ b/circuits/src/generation/register.rs
@@ -1,26 +1,30 @@
-use itertools::Itertools;
+use itertools::{chain, izip, Itertools};
 use mozak_runner::elf::Program;
+use mozak_runner::instruction::Args;
 use mozak_runner::state::State;
-use mozak_runner::vm::{ExecutionRecord, Row};
+use mozak_runner::vm::ExecutionRecord;
 use plonky2::hash::hash_types::RichField;
 
-use crate::register::columns::Register;
+use crate::register::columns::{dummy, init, read, write, Ops, Register};
 
-/// Returns the rows sorted in the order of the register 'address'.
+/// Sort rows into blocks of ascending addresses, and then sort each block
+/// internally by `augmented_clk`
 #[must_use]
-pub fn sort_by_address<F: RichField>(trace: Vec<Register<F>>) -> Vec<Register<F>> {
+pub fn sort_into_address_blocks<F: RichField>(mut trace: Vec<Register<F>>) -> Vec<Register<F>> {
+    trace.sort_by_key(|row| {
+        (
+            row.addr.to_noncanonical_u64(),
+            row.augmented_clk.to_noncanonical_u64(),
+        )
+    });
     trace
-        .into_iter()
-        // Sorting is stable, and rows are already ordered by row.state.clk
-        .sorted_by_key(|row| row.addr.to_noncanonical_u64())
-        .collect()
 }
 
 fn init_register_trace<F: RichField>(state: &State) -> Vec<Register<F>> {
     (1..32)
         .map(|i| Register {
             addr: F::from_canonical_u8(i),
-            is_init: F::ONE,
+            ops: init(),
             value: F::from_canonical_u32(state.get_register_value(i)),
             ..Default::default()
         })
@@ -31,11 +35,7 @@ fn init_register_trace<F: RichField>(state: &State) -> Vec<Register<F>> {
 pub fn pad_trace<F: RichField>(mut trace: Vec<Register<F>>) -> Vec<Register<F>> {
     let len = trace.len().next_power_of_two();
     trace.resize(len, Register {
-        // We want these 3 filter columns = 0,
-        // so we can constrain is_used = is_init + is_read + is_write.
-        is_init: F::ZERO,
-        is_read: F::ZERO,
-        is_write: F::ZERO,
+        ops: dummy(),
         // ..And fill other columns with duplicate of last real trace row.
         ..*trace.last().unwrap()
     });
@@ -61,66 +61,55 @@ pub fn generate_register_trace<F: RichField>(
         last_state,
     } = record;
 
-    let mut trace =
-        init_register_trace(record.executed.first().map_or(last_state, |row| &row.state));
+    let build_single_register_trace_row =
+        |reg: fn(&Args) -> u8, ops: Ops<F>, clk_offset: u64| -> _ {
+            executed
+                .iter()
+                .map(|row| &row.state)
+                .filter(move |state| reg(&state.current_instruction(program).args) != 0)
+                .map(move |state| {
+                    let reg = reg(&state.current_instruction(program).args);
 
-    for Row { state, .. } in executed {
-        let inst = state.current_instruction(program);
+                    // Ignore r0 because r0 should always be 0.
+                    // TODO: assert r0 = 0 constraint in CPU trace.
+                    Register {
+                        addr: F::from_canonical_u8(reg),
+                        value: F::from_canonical_u32(state.get_register_value(reg)),
+                        augmented_clk: F::from_canonical_u64(state.clk * 3 + clk_offset),
+                        ops,
+                        ..Default::default()
+                    }
+                })
+        };
+    let trace = sort_into_address_blocks(
+        chain!(
+            init_register_trace(record.executed.first().map_or(last_state, |row| &row.state)),
+            build_single_register_trace_row(|Args { rs1, .. }| *rs1, read(), 0),
+            build_single_register_trace_row(|Args { rs2, .. }| *rs2, read(), 1),
+            build_single_register_trace_row(|Args { rd, .. }| *rd, write(), 2)
+        )
+        .collect_vec(),
+    );
 
-        let augmented_clk = F::from_canonical_u64((state.clk) * 3);
-
-        // Ignore r0 because r0 should always be 0.
-        // TODO: assert r0 = 0 constraint in CPU trace.
-        (inst.args.rs1 != 0).then(|| {
-            trace.append(&mut vec![Register {
-                addr: F::from_canonical_u8(inst.args.rs1),
-                value: F::from_canonical_u32(state.get_register_value(inst.args.rs1)),
-                augmented_clk,
-                is_read: F::ONE,
-                ..Default::default()
-            }]);
-        });
-
-        (inst.args.rs2 != 0).then(|| {
-            trace.append(&mut vec![Register {
-                addr: F::from_canonical_u8(inst.args.rs2),
-                value: F::from_canonical_u32(state.get_register_value(inst.args.rs2)),
-                augmented_clk: augmented_clk + F::ONE,
-                is_read: F::ONE,
-                ..Default::default()
-            }]);
-        });
-
-        (inst.args.rd != 0).then(|| {
-            trace.append(&mut vec![Register {
-                addr: F::from_canonical_u8(inst.args.rd),
-                value: F::from_canonical_u32(state.get_register_value(inst.args.rd)),
-                augmented_clk: augmented_clk + F::TWO,
-                is_write: F::ONE,
-                ..Default::default()
-            }]);
-        });
-    }
-
-    trace = sort_by_address(trace);
-
-    // TODO: Rewrite this more efficiently and avoid allocating a temp vector.
     // Populate the `diff_augmented_clk` column, after addresses are sorted.
-    let mut diff_augmented_clk: Vec<F> = Vec::with_capacity(trace.len());
-    for (prev, curr) in trace.iter().circular_tuple_windows() {
-        diff_augmented_clk.push(curr.augmented_clk - prev.augmented_clk);
-    }
+    // TODO: Consider rewriting this to avoid allocating a temp vector.
+    let mut diff_augmented_clk = trace
+        .iter()
+        .circular_tuple_windows()
+        .map(|(lv, nv)| nv.augmented_clk - lv.augmented_clk)
+        .collect_vec();
+    // `.circular_tuple_windows` gives us tuples with indices (0, 1), (1, 2) ..
+    // (last, first==0), but we need (last, first=0), (0, 1), .. (last-1, last).
+    diff_augmented_clk.rotate_right(1);
 
-    for (i, reg) in trace.iter_mut().enumerate() {
-        reg.diff_augmented_clk = match i {
-            // It is OK to unwrap, since we know that we will definitely
-            // have some value in the trace.
-            0 => diff_augmented_clk.pop().unwrap(),
-            _ => diff_augmented_clk[i - 1],
-        }
-    }
-
-    pad_trace(trace)
+    pad_trace(
+        izip!(trace, diff_augmented_clk)
+            .map(|(reg, diff_augmented_clk)| Register {
+                diff_augmented_clk,
+                ..reg
+            })
+            .collect_vec(),
+    )
 }
 
 #[cfg(test)]

--- a/circuits/src/register/columns.rs
+++ b/circuits/src/register/columns.rs
@@ -1,7 +1,54 @@
+use plonky2::field::types::Field;
+
 use crate::columns_view::{columns_view_impl, make_col_map};
 
 columns_view_impl!(Register);
 make_col_map!(Register);
+
+#[repr(C)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
+pub struct Ops<T> {
+    /// Binary filter column that marks a row as the initialization of
+    /// a register.
+    pub is_init: T,
+
+    /// Binary filter column that marks a row as a register read.
+    pub is_read: T,
+
+    /// Binary filter column that marks a row as a register write.
+    pub is_write: T,
+}
+
+#[must_use]
+pub fn init<T: Field>() -> Ops<T> {
+    Ops {
+        is_init: T::ONE,
+        ..Default::default()
+    }
+}
+
+#[must_use]
+pub fn read<T: Field>() -> Ops<T> {
+    Ops {
+        is_read: T::ONE,
+        ..Default::default()
+    }
+}
+
+#[must_use]
+pub fn write<T: Field>() -> Ops<T> {
+    Ops {
+        is_write: T::ONE,
+        ..Default::default()
+    }
+}
+
+/// Create a dummy [`Ops`]
+///
+/// We want these 3 filter columns = 0,
+/// so we can constrain `is_used = is_init + is_read + is_write`.
+#[must_use]
+pub fn dummy<T: Field>() -> Ops<T> { Ops::default() }
 
 /// [`Design doc for RegisterSTARK`](https://www.notion.so/0xmozak/Register-File-STARK-62459d68aea648a0abf4e97aa0093ea2?pvs=4#0729f89ddc724967ac991c9e299cc4fc)
 #[repr(C)]
@@ -33,13 +80,6 @@ pub struct Register<T> {
     /// the `augmented_clk`.
     pub diff_augmented_clk: T,
 
-    /// Binary filter column that marks a row as the initialization of
-    /// a register.
-    pub is_init: T,
-
-    /// Binary filter column that marks a row as a register read.
-    pub is_read: T,
-
-    /// Binary filter column that marks a row as a register write.
-    pub is_write: T,
+    /// Columns that indicate what action is taken on the register.
+    pub ops: Ops<T>,
 }


### PR DESCRIPTION
Introduces a new column to the `RegisterStark` in order to prevent exploits that swap `augmented_clk`s around in the trace.

Originally raised here: https://github.com/0xmozak/mozak-vm/pull/668#discussion_r1339317540

This PR also changes the calculation of the `augmented_clk` - instead of `augmented_clk = clk * 2`, we do  `augmented_clk = clk * 3` (so we have space to differentiate between `rs1` and `rs2` reads.