### PR TITLE
chore(ci): add job to build examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,10 @@ jobs:
       - name: Install rust toolkit
         uses: ./.github/actions/rust
 
-      - name: Build examples 
+      - name: Build all examples 
         run: | 
           cd examples
-          for i in $(find */Cargo.toml); do
-            cargo build --manifest-path $i
-          done
+          git ls-files -z '*/Cargo.toml' | xargs -0 --max-args=1 -- cargo build --manifest-path
 
   cargo-fmt:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Closes #691 

(pretty primitive but works)

This is to ensure that examples do not break between PRs.