### PR TITLE
chore(ci): use install-action for taplo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install rust toolkit
-        uses: ./.github/actions/rust
-
-      - name: Install taplo
-        run: cargo install taplo-cli
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
 
       - name: taplo fmt
         run: taplo fmt --check


### PR DESCRIPTION
fixes CI failure in https://github.com/0xmozak/mozak-vm/pull/698