### PR TITLE
refactor memory is-writable to help with half word memory

### DIFF
--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -42,10 +42,6 @@ pub fn generate_memory_trace_from_execution<F: RichField>(
         })
         .map(|row| {
             let addr: F = get_memory_inst_addr(row);
-            let _: u32 = addr
-                .to_canonical_u64()
-                .try_into()
-                .expect("casting addr (F) to u32 should not fail");
             let op = &(row.state).current_instruction(program).op;
             Memory {
                 addr,


### PR DESCRIPTION
more generic way to handle is_writable 
depends on https://github.com/0xmozak/mozak-vm/pull/716