### PR TITLE
Derive `Copy` for `Aux`

### DIFF
--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -46,7 +46,7 @@ pub fn generate_cpu_trace<F: RichField>(
         // The last state is the final state after the last execution.  Thus naturally it has no
         // associated auxiliarye execution information. We use a dummy aux to make the row
         // generation work, but we could refactor to make this unnecessary.
-        aux: executed.last().unwrap().aux.clone(),
+        aux: executed.last().unwrap().aux,
     }];
 
     for Row { state, aux } in chain![executed, last_row] {

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -99,7 +99,7 @@ impl From<&Program> for State {
 }
 
 /// Auxiliary information about the instruction execution
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Aux {
     // This could be an Option<u32>, but given how Risc-V instruction are specified,
     // 0 serves as a default value just fine.


### PR DESCRIPTION
This saves us an explicit clone, and just makes `Aux` slightly nicer to handle.

Extracted from https://github.com/0xmozak/mozak-vm/pull/711