### PR TITLE
Incomplete features begone

### DIFF
--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(stmt_expr_attributes)]
 #![feature(coverage_attribute)]
 #![feature(register_tool)]


### PR DESCRIPTION
We no longer need to enable incomplete features, now that `generic_const_exprs` is gone.