### PR TITLE
Always require `serde`

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -19,7 +19,7 @@ im = "15.1.0"
 itertools = "0.11.0"
 log = "0.4.20"
 proptest = { version = "1.2.0", optional = true }
-serde = { version = "1.0.188", optional = true }
+serde = { version = "1.0.188" }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -33,7 +33,6 @@ harness = false
 name = "fibonacci"
 
 [features]
-default = ["std"]
-serialize = ["serde", "im/serde"]
+default = ["std", "im/serde"]
 std = ["anyhow/std"]
 test = ["env_logger", "proptest"]

--- a/runner/src/instruction.rs
+++ b/runner/src/instruction.rs
@@ -1,11 +1,9 @@
 //! RV32I Base Integer Instructions + RV32M Multiply Extension
 use derive_more::Display;
-#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 /// Arguments of a Risc-V instruction
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Args {
     /// Destination Register
     pub rd: u8,
@@ -18,8 +16,7 @@ pub struct Args {
 }
 
 /// Operands of RV32I + RV32M
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Display)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Display, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum Op {
     // RV32I Base Integer Instructions
@@ -116,8 +113,7 @@ pub const NOOP: Instruction = Instruction {
 };
 
 /// Internal representation of a decoded RV32 [Instruction]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Instruction {
     /// Operand of Instruction
     pub op: Op,

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Result};
 use derive_more::Deref;
 use im::hashmap::HashMap;
 use log::trace;
-#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::elf::{Code, Data, Program};
@@ -40,8 +39,7 @@ pub struct State {
     pub io_tape: IoTape,
 }
 
-#[derive(Clone, Debug, Default, Deref)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Default, Deref, Serialize, Deserialize)]
 pub struct IoTape {
     #[deref]
     pub data: Rc<Vec<u8>>,


### PR DESCRIPTION
This is to simplify our dependencies, and to support https://github.com/0xmozak/mozak-vm/pull/745