### PR TITLE
Fix non-deterministic program hash

### DIFF
--- a/circuits/src/generation/program.rs
+++ b/circuits/src/generation/program.rs
@@ -5,19 +5,19 @@ use crate::cpu::columns::Instruction;
 use crate::program::columns::{InstructionRow, ProgramRom};
 use crate::utils::pad_trace_with_default;
 
-/// Generates a program ROM trace
+/// Generates a program ROM trace from a given program.
 #[must_use]
 pub fn generate_program_rom_trace<F: RichField>(program: &Program) -> Vec<ProgramRom<F>> {
-    pad_trace_with_default(
-        program
-            .ro_code
-            .iter()
-            .map(|(&pc, &inst)| ProgramRom {
-                filter: F::ONE,
-                inst: InstructionRow::from(
-                    Instruction::from((pc, inst)).map(F::from_canonical_u32),
-                ),
-            })
-            .collect(),
-    )
+    let mut roms = program
+        .ro_code
+        .iter()
+        .map(|(&pc, &inst)| ProgramRom {
+            filter: F::ONE,
+            inst: InstructionRow::from(Instruction::from((pc, inst)).map(F::from_canonical_u32)),
+        })
+        .collect::<Vec<_>>();
+
+    roms.sort_by_key(|entry| entry.inst.pc.to_canonical_u64());
+
+    pad_trace_with_default(roms)
 }


### PR DESCRIPTION
Iterating over a HashMap leads to non-deterministic behavior and an unpredictable program hash.