### PR TITLE
chore(ci): fix macos tests

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install rust toolkit
         uses: ./.github/actions/rust
 
+      - name: Build ELF(s) for benchmarking
+        run: cd examples/fibonacci && cargo build --release
+
       - name: Run tests
         run: cargo test --locked --all-targets
 


### PR DESCRIPTION
closes #775 

we need to build the fibonacci ELF used for benchmarking in its own separate step.