### PR TITLE
temp fix cpu stark in issue #793

### DIFF
--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -292,17 +292,17 @@ pub fn generate_permuted_inst_trace<F: RichField>(
         })
         .collect();
 
-    let used_pcs: HashSet<F> = cpu_trace.iter().map(|row| row.inst.pc).collect();
+    // let used_pcs: HashSet<F> = cpu_trace.iter().map(|row| row.inst.pc).collect();
 
-    // Filter program_rom to contain only instructions with the pc that are not in
-    // used_pcs
-    let unused_instructions: Vec<_> = program_rom
-        .iter()
-        .filter(|row| !used_pcs.contains(&row.inst.pc))
-        .copied()
-        .collect();
+    // // Filter program_rom to contain only instructions with the pc that are not in
+    // // used_pcs
+    // let unused_instructions: Vec<_> = program_rom
+    //     .iter()
+    //     .filter(|row| !used_pcs.contains(&row.inst.pc))
+    //     .copied()
+    //     .collect();
 
-    cpu_trace.extend(unused_instructions);
+    // cpu_trace.extend(unused_instructions);
     cpu_trace
 }
 


### PR DESCRIPTION
Refers to #793
`generate_permuted_inst_trace` appends some unused instructions from programrom into the cpu trace.
These values have filter 0, but in program rom, filter is reserved for marking duplicates, not unused instructions.
Hence when unused instructions are added, the constraint
```rust
for (lv_col, nv_col) in izip![lv.inst, nv.inst] {
        yield_constr.constraint((nv.filter - P::ONES) * (lv_col - nv_col));
    }
```
fails on last row corresponding for used instructions

Do we even need to add the unused instructions? If not, we can remove the lines.
If yes, we need to add a column to filter out unused instructions