### PR TITLE
Fix permuted CPU trace generation

### DIFF
--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -367,10 +367,10 @@ mod tests {
             CpuState {
                 inst: Instruction {
                     pc: 1,
-                    ops: selection(4),
-                    rs1_select: selection(4),
-                    rs2_select: selection(4),
-                    rd_select: selection(4),
+                    ops: selection(3),
+                    rs1_select: selection(2),
+                    rs2_select: selection(1),
+                    rd_select: selection(1),
                     imm_value: 4,
                     ..Default::default()
                 },
@@ -425,8 +425,8 @@ mod tests {
             },
             ProgramRom {
                 inst: InstructionRow {
-                    pc: 1,
-                    inst_data: reduce_with_powers(vec![3, 0, 0, 3, 3, 3, 3]),
+                    pc: 3,
+                    inst_data: reduce_with_powers(vec![2, 0, 0, 1, 2, 3, 1]),
                 },
                 filter: 0,
             },


### PR DESCRIPTION
This solves one part of https://github.com/0xmozak/mozak-vm/issues/793

Fix the issue: we need to add unused instructions, but we do not want to add duplicated unused instructions.