### PR TITLE
Fix extract data from ELF

### DIFF
--- a/runner/src/elf.rs
+++ b/runner/src/elf.rs
@@ -159,7 +159,7 @@ impl Program {
                     // This is as defined in the elf man page, under PT_LOAD: https://www.man7.org/linux/man-pages/man5/elf.5.html
                     ensure!(
                         file_size <= mem_size,
-                        "The file size can not be larger than the memory size in segment"
+                        "The file size {file_size} can not be larger than the memory size {mem_size} in the segment."
                     );
                     Ok((vaddr..).zip(
                         // We zero out the remaining memory, according to the spec above.


### PR DESCRIPTION
ELF headers might look like this
```
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00010034 0x00010034 0x000c0 0x000c0 R   0x4
  LOAD           0x000000 0x00010000 0x00010000 0x00570 0x00570 R   0x1000
  LOAD           0x000570 0x00011570 0x00011570 0x01fac 0x01fac R E 0x1000
  LOAD           0x00251c 0x0001451c 0x0001451c 0x00000 0x00014 RW  0x1000
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0
  RISCV_ATTRIBUT 0x002564 0x00000000 0x00000000 0x00021 0x00021 R   0x1
  ```
  As we see in 3rd `LOAD`, `FileSiz` could be strictly less than `MemSiz`.
  This could arise in situations referring to uninitialized data, where there are no bytes stored for the object, but memory is still reserved for the object. Like in `.bss`. Indeed, the above example refers to `.sbss` section.
  Previously, we just extracted `min(FileSiz, MemSize)` amount of data starting from offset `PhysAddr`. This might fail to account for the case described above.
The fix in this PR accounts for extracting the missing addresses, and zeroing them out if they correspond to uninitialised data.

See https://stackoverflow.com/questions/13437732/elf-program-headers-memsiz-vs-filesiz