### PR TITLE
suggestion(#751): test for program stark

### DIFF
--- a/circuits/src/program/stark.rs
+++ b/circuits/src/program/stark.rs
@@ -61,3 +61,24 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for ProgramStark<
 
     fn constraint_degree(&self) -> usize { 3 }
 }
+
+#[cfg(test)]
+mod tests {
+    use plonky2::plonk::config::{GenericConfig, Poseidon2GoldilocksConfig};
+    use starky::stark_testing::test_stark_circuit_constraints;
+
+    use super::*;
+
+    const D: usize = 2;
+    type C = Poseidon2GoldilocksConfig;
+    type F = <C as GenericConfig<D>>::F;
+    type S = ProgramStark<F, D>;
+
+    #[test]
+    fn test_circuit() -> anyhow::Result<()> {
+        let stark = S::default();
+        test_stark_circuit_constraints::<F, C, S, D>(stark)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
See: https://github.com/0xmozak/mozak-vm/pull/751#discussion_r1375781714

There is a utility function called `test_stark_circuit_constraints()`within `stark_testing` in `starky` that helps ensure consistency between the native constraints and the circuit constraints. We might want to add it here as well - it's not that important in this current PR since the constraints are simple (only a binary constraint), but it could serve as example code for future circuit constraints that are more complex that we want to ensure behave the same.