### PR TITLE
Slightly optimize dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["cli", "runner", "circuits"]
 resolver = "2"
 
-[profile.test]
+[profile.dev]
 # We are running our tests with optimizations turned on to make them faster.
 # Plase turn optimizations off, when you want accurate stack traces for debugging.
 lto = "thin"


### PR DESCRIPTION
The test profile inherits from the dev profile.  We want to (slightly) optimize the dev profile, so that a simple `cargo run ...` is reasonably fast.

Kapil's performance investigations have shown that opt-level 1 gets us most of the way, and is still quick to compile.