### PR TITLE
chore(deps): remove unused `hex-literal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,12 +652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,7 +925,6 @@ dependencies = [
  "derive_more",
  "elf",
  "env_logger",
- "hex-literal",
  "im",
  "itertools 0.11.0",
  "log",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -25,7 +25,6 @@ serde = { version = "1.0.190", features = ["derive"] }
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 env_logger = { version = "0.10.0" }
-hex-literal = "0.4.1"
 proptest = "1.2.0"
 serde_json = "1.0.105"
 test-case = "3.2.1"


### PR DESCRIPTION
Closes #816 

```console
$ rg hex_literal
examples/sha2/main.rs
6:use hex_literal::hex;

examples/poseidon2/main.rs
7:use hex_literal::hex;
```