### PR TITLE
fix: hide `bench_function` so `cargo test` can run

### DIFF
--- a/circuits/src/cli_benches/mod.rs
+++ b/circuits/src/cli_benches/mod.rs
@@ -1,2 +1,3 @@
+#[cfg(any(feature = "test", test))]
 pub mod bench_functions;
 // TODO: Maybe we should move cli_benches elsewhere later.


### PR DESCRIPTION
Without this fix, running `cargo test` in the `circuits` directory results in:
```
error[E0432]: unresolved import `crate::test_utils`
 --> circuits/src/cli_benches/bench_functions.rs:7:12
  |
7 | use crate::test_utils::prove_and_verify_mozak_stark;
  |            ^^^^^^^^^^
  |            |
  |            unresolved import
  |            help: a similar path exists: `mozak_runner::test_utils`
```

Disabling this module for non-`test` does not appear to impact anything.