### PR TITLE
Using section headers instead of program headers

### DIFF
--- a/runner/src/elf.rs
+++ b/runner/src/elf.rs
@@ -149,27 +149,29 @@ impl Program {
             .ok_or_else(|| anyhow!("Missing segment table"))?;
         ensure!(segments.len() <= 256, "Too many program headers");
 
-        let extract =
-            |check_flags: fn(u32) -> bool| {
-                segments
-                    .iter()
-                    // It is OK to cast this as u32 because we already check that we're reading a
-                    // 32-bit ELF. The elf parsing crate simply does an `as u64`
-                    // after parsing `sh_flags` as a u32: https://docs.rs/elf/latest/src/elf/section.rs.html#82
-                    .filter(|s| {
-                        check_flags(u32::try_from(s.sh_flags).expect(
-                            "cast from u64 sh_flags should succeed if reading a 32-bit ELF",
-                        ))
-                    })
-                    .map(|segment| -> Result<_> {
-                        let file_size: usize = segment.sh_size.try_into()?;
-                        let vaddr: u32 = segment.sh_addr.try_into()?;
-                        let offset = segment.sh_offset.try_into()?;
-                        Ok((vaddr..).zip(input[offset..].iter().take(file_size).copied()))
-                    })
-                    .flatten_ok()
-                    .try_collect()
-            };
+        let extract = |check_flags: fn(u32) -> bool| {
+            segments
+                .iter()
+                // It is OK to cast this as u32 because we already check that we're reading a
+                // 32-bit ELF. The elf parsing crate simply does an `as u64`
+                // after parsing `sh_flags` as a u32: https://docs.rs/elf/latest/src/elf/section.rs.html#82
+                .filter_map(|s: elf::section::SectionHeader| {
+                    let flags = u32::try_from(s.sh_flags).ok()?;
+                    if check_flags(flags) {
+                        Some(s)
+                    } else {
+                        None
+                    }
+                })
+                .map(|segment| -> Result<_> {
+                    let file_size: usize = segment.sh_size.try_into()?;
+                    let vaddr: u32 = segment.sh_addr.try_into()?;
+                    let offset = segment.sh_offset.try_into()?;
+                    Ok((vaddr..).zip(input[offset..].iter().take(file_size).copied()))
+                })
+                .flatten_ok()
+                .try_collect()
+        };
 
         let ro_memory = Data(extract(|flags| {
             flags & elf::abi::SHF_WRITE == elf::abi::SHF_NONE


### PR DESCRIPTION
To fix https://github.com/0xmozak/mozak-vm/pull/856
Previously, we only used `LOAD` section from ELF for init memory 
```
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00010034 0x00010034 0x000c0 0x000c0 R   0x4
  LOAD           0x000000 0x00010000 0x00010000 0x01210 0x01210 R   0x1000
  LOAD           0x001210 0x00012210 0x00012210 0x03258 0x03258 R E 0x1000
  LOAD           0x004468 0x00016468 0x00016468 0x00008 0x0003c RW  0x1000
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0
  RISCV_ATTRIBUT 0x0044b8 0x00000000 0x00000000 0x00021 0x00021 R   0x1
  ```
  As pointed out in the failing test above, it seems that other sections, like `RISCV_ATTRIBUT` might be important too.
  And its a pain to keep track of all such required sections and make sure they are loaded.
  
I tried to fix by just removing the filter (which would allow us to use all headers)
  ```rust
segments
      .iter()
      .filter(|s: &ProgramHeader| s.p_type == elf::abi::PT_LOAD)  // removed
  ```
  But then a weird thing happened. `mozak-runner::riscv_tests add` and the corresponding tests started to fail.
  Inspecting the ELFs led me to even weirder thing.
  ```
readelf --headers rv32ui-p-add

  Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  RISCV_ATTRIBUT 0x002048 0x00000000 0x00000000 0x00050 0x00000 R   0x1
  LOAD           0x001000 0x80000000 0x80000000 0x006bc 0x006bc R E 0x1000
  LOAD           0x002000 0x80001000 0x80001000 0x00048 0x00048 RW  0x1000
  ```
in `RISCV_ATTRIBUT`, `MemSiz(0)` is less than `FileSiz(0x50)`!

Since its even bigger pain to keep track of all headers where this can happen, I decided to implement everything in terms of section headers, instead of program headers. It seems that section headers are superset of data contained in program headers, and we can refer to the actual size of section through `Size`.

For reference, section headers corresponding to program headers of `fibonacci-input` ELF looks like this.
```
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .rodata           PROGBITS        000100f4 0000f4 00111c 00  AM  0   0  4
  [ 2] .text             PROGBITS        00012210 001210 003258 00  AX  0   0  4
  [ 3] .sdata            PROGBITS        00016468 004468 000008 00  WA  0   0  4
  [ 4] .sbss             NOBITS          00016470 004470 00000c 00  WA  0   0  4
  [ 5] .bss              NOBITS          0001647c 004470 000028 00  WA  0   0  4
  [ 6] .comment          PROGBITS        00000000 004470 000048 01  MS  0   0  1
  [ 7] .riscv.attributes RISCV_ATTRIBUTE 00000000 0044b8 000021 00      0   0  1
  [ 8] .symtab           SYMTAB          00000000 0044dc 000ef0 10     10 232  4
  [ 9] .shstrtab         STRTAB          00000000 0053cc 000056 00      0   0  1
  [10] .strtab           STRTAB          00000000 005422 002f6a 00      0   0  1
  ```
 So consider this PR as just a (perhaps temporary) measure to ensure nothing is missed while loading the ELF.
Eventually we might want come up with a list of section headers and ensure we are only loading those, and not cluttering MemoryInit table with unnecessary stuff.
  Suggestions are welcome.
  
  
  
  