### PR TITLE
fix: bench requires `test` feature

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -46,3 +46,4 @@ test = []
 [[bench]]
 harness = false
 name = "simple_prover"
+required-features = ["test"]


### PR DESCRIPTION
Uses `test_utils`, which only exists when `test` feature is on.