### PR TITLE
Speed up CI tests

### DIFF
--- a/circuits/benches/simple_prover.rs
+++ b/circuits/benches/simple_prover.rs
@@ -36,7 +36,7 @@ fn bench_prove_verify_all(c: &mut Criterion) {
                     },
                 },
             ];
-            let (program, record) = simple_test_code(instructions, &[], &[(1, 1 << 16)]);
+            let (program, record) = simple_test_code(instructions, &[], &[(1, 1 << 10)]);
             prove_and_verify_mozak_stark(&program, &record, &StarkConfig::standard_fast_config())
         })
     });


### PR DESCRIPTION
Our CI tests are running with
```sh
MOZAK_STARK_DEBUG=true cargo nextest run --locked --all-targets
```

`--all-targets` makes nextest also run the benchmarks.  It's useful to make sure that the benchmarks build and can run.  But the latter is taking a long time on the slow GitHub hosted runners:

```
        SLOW [> 60.000s] mozak-circuits::bench/simple_prover prove_verify_all/prove_verify_all
        PASS [  80.461s] mozak-circuits::bench/simple_prover prove_verify_all/prove_verify_all
```

So here we dial down the number of iterations to 1/64th its original value.