### PR TITLE
Fix `cargo udeps`: use vendored openssl

### DIFF
--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/rust
 
       - name: Install cargo-udeps
-        run: cargo install --locked cargo-udeps
+        run: cargo install --features vendored-openssl --locked cargo-udeps
 
       - name: Check for unused dependencies
         run: cargo udeps --workspace --all-targets --all-features


### PR DESCRIPTION
We are having trouble running `cargo udeps` on our self-hosted CI runners.

See eg https://github.com/0xmozak/mozak-vm/actions/runs/6922097050/job/18883191870

```
error: failed to run custom build command for `openssl-sys v0.9.93`
```

Using vendored openssl might help.