### PR TITLE
chore(poseidon2): remove redundant trace_to_poly_values

### DIFF
--- a/circuits/src/poseidon2/stark.rs
+++ b/circuits/src/poseidon2/stark.rs
@@ -3,8 +3,6 @@ use std::marker::PhantomData;
 use mozak_circuits_derive::StarkNameDisplay;
 use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::packed::PackedField;
-use plonky2::field::polynomial::PolynomialValues;
-use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
 use plonky2::hash::poseidon2::Poseidon2;
 use plonky2::iop::ext_target::ExtensionTarget;


### PR DESCRIPTION
Unused code in `poseidon2/stark.rs` and we should use the fn in utils anyway.