### PR TITLE
ci: fix partial cache hit

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - id: local-cache
       name: Cache Rust artifacts (Local)
-      uses: 0xmozak/rust-cache@7c0d9af4736f6d9d1290c90229ec0de3745230e5
+      uses: 0xmozak/rust-cache@d5f76b3ac4ba287ab299d4d3586d5cd11ad21cab
       with:
         prefix-key: ${{ inputs.cache-key != '' && inputs.cache-key || null }}
         cache-provider: "local"
@@ -65,7 +65,7 @@ runs:
       run: echo cache-hit=${{ steps.local-cache.outputs.cache-hit }} partial-hit=${{ steps.local-cache.outputs.partial-hit }}
 
     - name: Cache Rust artifacts (Remote)
-      uses: 0xmozak/rust-cache@7c0d9af4736f6d9d1290c90229ec0de3745230e5
+      uses: 0xmozak/rust-cache@d5f76b3ac4ba287ab299d4d3586d5cd11ad21cab
       if: ${{ steps.local-cache.outputs.cache-hit != 'true'}}
       with:
         require-full-match: ${{ steps.local-cache.outputs.partial-hit }}


### PR DESCRIPTION
Added in more configuration for partial cache hits to avoid downloading when unnecessary. I've left in a debug step to make it easier to debug if this ever breaks.

Also rename CI ids to make more sense.