### PR TITLE
fix: add flag to `riscv_tests`

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -45,6 +45,10 @@ enable_poseidon_starks = []
 enable_register_starks = []
 test = []
 
+[[test]]
+name = "riscv_tests"
+required-features = ["test"]
+
 [[bench]]
 harness = false
 name = "simple_prover"


### PR DESCRIPTION
this fixes just running `cargo test`

```bash
mozak-vm/circuits$ cargo test
   Compiling mozak-circuits v0.1.0 (/config/workspace/mozak/mozak-vm/circuits)
error[E0432]: unresolved import `mozak_circuits::test_utils`
 --> circuits/tests/riscv_tests.rs:4:21
  |
4 | use mozak_circuits::test_utils::prove_and_verify_mozak_stark;
  |                     ^^^^^^^^^^ could not find `test_utils` in `mozak_circuits`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `mozak-circuits` (test "riscv_tests") due to previous error
```