### PR TITLE
CLI: make iotape inputs optional

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,21 +50,21 @@ enum Command {
     /// the registers
     Run {
         elf: Input,
-        io_tape_private: Input,
-        io_tape_public: Input,
+        io_tape_private: Option<Input>,
+        io_tape_public: Option<Input>,
     },
     /// Prove and verify the execution of a given ELF
     ProveAndVerify {
         elf: Input,
-        io_tape_private: Input,
-        io_tape_public: Input,
+        io_tape_private: Option<Input>,
+        io_tape_public: Option<Input>,
     },
     /// Prove the execution of given ELF and write proof to file.
     Prove {
         elf: Input,
-        io_tape_private: Input,
-        io_tape_public: Input,
         proof: Output,
+        io_tape_private: Option<Input>,
+        io_tape_public: Option<Input>,
         recursive_proof: Option<Output>,
     },
     /// Verify the given proof from file.
@@ -116,8 +116,8 @@ fn main() -> Result<()> {
             let program = load_program(elf)?;
             let state = State::<GoldilocksField>::new(
                 program.clone(),
-                &load_tape(io_tape_private)?,
-                &load_tape(io_tape_public)?,
+                &load_tape(io_tape_private.unwrap_or_default())?,
+                &load_tape(io_tape_public.unwrap_or_default())?,
             );
             let state = step(&program, state)?.last_state;
             debug!("{:?}", state.registers);
@@ -130,8 +130,8 @@ fn main() -> Result<()> {
             let program = load_program(elf)?;
             let state = State::<GoldilocksField>::new(
                 program.clone(),
-                &load_tape(io_tape_private)?,
-                &load_tape(io_tape_public)?,
+                &load_tape(io_tape_private.unwrap_or_default())?,
+                &load_tape(io_tape_public.unwrap_or_default())?,
             );
             let record = step(&program, state)?;
             prove_and_verify_mozak_stark(&program, &record, &config)?;
@@ -146,8 +146,8 @@ fn main() -> Result<()> {
             let program = load_program(elf)?;
             let state = State::<GoldilocksField>::new(
                 program.clone(),
-                &load_tape(io_tape_private)?,
-                &load_tape(io_tape_public)?,
+                &load_tape(io_tape_private.unwrap_or_default())?,
+                &load_tape(io_tape_public.unwrap_or_default())?,
             );
             let record = step(&program, state)?;
             let stark = if cli.debug {

--- a/cli/src/tests/integration_test.rs
+++ b/cli/src/tests/integration_test.rs
@@ -29,9 +29,9 @@ fn test_prove_and_verify_recursive_proof_command() {
             "--",
             "prove",
             elf_file,
+            &proof_file.to_string_lossy(),
             &io_tape_private.to_string_lossy(),
             &io_tape_public.to_string_lossy(),
-            &proof_file.to_string_lossy(),
             &recursive_proof_file.to_string_lossy(),
         ])
         .output()

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -185,6 +185,10 @@ impl<F: RichField> State<F> {
             pc,
             rw_memory,
             ro_memory,
+            // TODO(bing): Handle the case where iotapes are
+            // in .mozak_global sections in the RISC-V binary.
+            // Now, the CLI simply does unwrap_or_default() to either
+            // use an iotape from file or default to an empty input.
             io_tape: (io_tape_private, io_tape_public).into(),
             ..Default::default()
         }


### PR DESCRIPTION
Unblocks #1002
This PR makes the iotape `Input` into `Option<Input>`, few
reasons:

1) With recent changes, the io tapes are now embedded within our
RISC-V binaries in the `.mozak_globals` section. We want to load from
them instead.
2) However! We may also want to provide the optionality of overriding
the embedded io tapes for debugging purposes (this would be the main use
case). This is when an io tape input into the cli is useful.
3) There are also certain programs/examples that require an input even for the
native versions of the binaries.