### PR TITLE
fmt: fix bss formatting

### DIFF
--- a/examples/bss-tester/main.rs
+++ b/examples/bss-tester/main.rs
@@ -1,12 +1,13 @@
 #![no_main]
 #![no_std]
-use core::{assert_eq};
+use core::assert_eq;
+
 // For BSS / SBSS
 // ref: https://stackoverflow.com/questions/40465933/how-do-i-write-rust-code-that-places-globals-statics-in-a-populated-bss-segmen
 static mut XYZ: [u8; 20] = [51; 20];
 
 pub fn main() {
-    unsafe{
+    unsafe {
         assert_eq!(XYZ[2], 51);
         guest::env::write(&XYZ);
     }


### PR DESCRIPTION
small fix to formatting for bss-tester, extracted from #1002 