### PR TITLE
chore: bump rust-nightly to 2024-01-15

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-01-01"
+channel = "nightly-2024-01-15"
 components = ["rustfmt", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
Bumping to the latest `rust-nightly` available on [Rustup components history](https://rust-lang.github.io/rustup-components-history/).

Do note that this will bump `nightly` to `nightly-2024-01-15` on your system.