### PR TITLE
chore(vm): fix typo `InputOuput` -> `InputOutput`

### DIFF
--- a/circuits/src/memory_io/stark.rs
+++ b/circuits/src/memory_io/stark.rs
@@ -17,18 +17,18 @@ use crate::stark::utils::{is_binary, is_binary_ext_circuit};
 
 #[derive(Copy, Clone, Default, StarkNameDisplay)]
 #[allow(clippy::module_name_repetitions)]
-pub struct InputOuputMemoryStark<F, const D: usize> {
+pub struct InputOutputMemoryStark<F, const D: usize> {
     pub _f: PhantomData<F>,
 }
 
-impl<F, const D: usize> HasNamedColumns for InputOuputMemoryStark<F, D> {
+impl<F, const D: usize> HasNamedColumns for InputOutputMemoryStark<F, D> {
     type Columns = InputOutputMemory<F>;
 }
 
 const COLUMNS: usize = NUM_IO_MEM_COLS;
 const PUBLIC_INPUTS: usize = 0;
 
-impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for InputOuputMemoryStark<F, D> {
+impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for InputOutputMemoryStark<F, D> {
     type EvaluationFrame<FE, P, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
 
         where
@@ -165,7 +165,7 @@ mod tests {
     use proptest::proptest;
     use starky::stark_testing::test_stark_circuit_constraints;
 
-    use crate::memory_io::stark::InputOuputMemoryStark;
+    use crate::memory_io::stark::InputOutputMemoryStark;
     use crate::stark::mozak_stark::MozakStark;
     use crate::test_utils::{ProveAndVerify, D, F};
 
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn test_circuit() -> anyhow::Result<()> {
         type C = Poseidon2GoldilocksConfig;
-        type S = InputOuputMemoryStark<F, D>;
+        type S = InputOutputMemoryStark<F, D>;
 
         let stark = S::default();
         test_stark_circuit_constraints::<F, C, S, D>(stark)?;

--- a/circuits/src/stark/mozak_stark.rs
+++ b/circuits/src/stark/mozak_stark.rs
@@ -14,7 +14,7 @@ use crate::cross_table_lookup::{Column, CrossTableLookup};
 use crate::memory::stark::MemoryStark;
 use crate::memory_fullword::stark::FullWordMemoryStark;
 use crate::memory_halfword::stark::HalfWordMemoryStark;
-use crate::memory_io::stark::InputOuputMemoryStark;
+use crate::memory_io::stark::InputOutputMemoryStark;
 use crate::memory_zeroinit::stark::MemoryZeroInitStark;
 use crate::memoryinit::stark::MemoryInitStark;
 use crate::poseidon2::stark::Poseidon2_12Stark;
@@ -75,9 +75,9 @@ pub struct MozakStark<F: RichField + Extendable<D>, const D: usize> {
     #[StarkSet(stark_kind = "FullWordMemory")]
     pub fullword_memory_stark: FullWordMemoryStark<F, D>,
     #[StarkSet(stark_kind = "IoMemoryPrivate")]
-    pub io_memory_private_stark: InputOuputMemoryStark<F, D>,
+    pub io_memory_private_stark: InputOutputMemoryStark<F, D>,
     #[StarkSet(stark_kind = "IoMemoryPublic")]
-    pub io_memory_public_stark: InputOuputMemoryStark<F, D>,
+    pub io_memory_public_stark: InputOutputMemoryStark<F, D>,
     #[cfg_attr(
         feature = "enable_register_starks",
         StarkSet(stark_kind = "RegisterInit")
@@ -336,8 +336,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Default for MozakStark<F, D> 
             fullword_memory_stark: FullWordMemoryStark::default(),
             register_init_stark: RegisterInitStark::default(),
             register_stark: RegisterStark::default(),
-            io_memory_private_stark: InputOuputMemoryStark::default(),
-            io_memory_public_stark: InputOuputMemoryStark::default(),
+            io_memory_private_stark: InputOutputMemoryStark::default(),
+            io_memory_public_stark: InputOutputMemoryStark::default(),
             poseidon2_sponge_stark: Poseidon2SpongeStark::default(),
             poseidon2_stark: Poseidon2_12Stark::default(),
             poseidon2_output_bytes_stark: Poseidon2OutputBytesStark::default(),

--- a/circuits/src/test_utils.rs
+++ b/circuits/src/test_utils.rs
@@ -42,7 +42,7 @@ use crate::generation::xor::generate_xor_trace;
 use crate::memory::stark::MemoryStark;
 use crate::memory_fullword::stark::FullWordMemoryStark;
 use crate::memory_halfword::stark::HalfWordMemoryStark;
-use crate::memory_io::stark::InputOuputMemoryStark;
+use crate::memory_io::stark::InputOutputMemoryStark;
 use crate::rangecheck::stark::RangeCheckStark;
 use crate::register::stark::RegisterStark;
 use crate::registerinit::stark::RegisterInitStark;
@@ -265,9 +265,9 @@ impl ProveAndVerify for FullWordMemoryStark<F, D> {
     }
 }
 
-impl ProveAndVerify for InputOuputMemoryStark<F, D> {
+impl ProveAndVerify for InputOutputMemoryStark<F, D> {
     fn prove_and_verify(_program: &Program, record: &ExecutionRecord<F>) -> Result<()> {
-        type S = InputOuputMemoryStark<F, D>;
+        type S = InputOutputMemoryStark<F, D>;
         let config = fast_test_config();
 
         let stark = S::default();


### PR DESCRIPTION
As commit message says.