### PR TITLE
chore: Add rust-analyzer

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-01-15"
+channel = "nightly-2024-01-17"
 components = ["rustfmt", "rust-src", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
Previously running `rust-analyzer` from the CLI would complain that it is missing a component for this toolchain.

This change is needed if anyone wants to use a text editor that uses `rust-analyzer` that is installed by `rustup` (`emacs`, `neovim`, etc).