### PR TITLE
Remove obsolete `dead_code` marker

### DIFF
--- a/circuits/src/stark/proof.rs
+++ b/circuits/src/stark/proof.rs
@@ -325,7 +325,6 @@ pub struct StarkProofWithMetadata<F, C, const D: usize>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>, {
-    #[allow(dead_code)]
     // TODO: Support serialization of `init_challenger_state`.
     #[serde(skip)]
     pub(crate) init_challenger_state: <C::Hasher as Hasher<F>>::Permutation,
@@ -338,7 +337,6 @@ where
 #[serde(bound = "")]
 pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     pub proofs_with_metadata: TableKindArray<StarkProofWithMetadata<F, C, D>>,
-    #[allow(dead_code)]
     // TODO: Support serialization of `ctl_challenges`.
     #[serde(skip)]
     pub(crate) ctl_challenges: GrandProductChallengeSet<F>,


### PR DESCRIPTION
It looks like we are using that code now.