### PR TITLE
Nicer CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,15 @@ jobs:
           local-cache: ${{ needs.check-runner.outputs.runner-label == 'self-hosted' }}
 
       - name: Compile
-        run: cargo nextest run --no-run --locked --features="enable_poseidon_starks" --all-targets
+        run: nice cargo nextest run --no-run --locked --features="enable_poseidon_starks" --all-targets
 
       - name: Test
-        run: MOZAK_STARK_DEBUG=true cargo nextest run --no-fail-fast --locked --features="enable_poseidon_starks" --all-targets
+        run: MOZAK_STARK_DEBUG=true nice cargo nextest run --no-fail-fast --locked --features="enable_poseidon_starks" --all-targets
 
       - name: Build and run examples
         run: |
-          cd examples && cargo build --release
-          cd .. && ./run_examples.sh
+          cd examples && nice cargo build --release
+          cd .. && nice ./run_examples.sh
 
   cargo-clippy:
     needs: check-runner

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests for coverage
         # skip-clean is there to make tarpaulin not re-build unnecessarily,
         # so caching dependencies works.
-        run: cargo tarpaulin --release --skip-clean --engine llvm --locked --workspace --out Xml
+        run: nice cargo tarpaulin --release --skip-clean --engine llvm --locked --workspace --out Xml
 
       - name: Coverage Comment
         uses: ewjoachim/coverage-comment-action@v1.0.3

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -29,10 +29,10 @@ jobs:
         uses: ./.github/actions/rust
 
       - name: Install cargo-udeps
-        run: cargo install --features vendored-openssl --locked cargo-udeps
+        run: nice cargo install --features vendored-openssl --locked cargo-udeps
 
       - name: Check for unused dependencies
-        run: cargo udeps --workspace --all-targets --all-features
+        run: nice cargo udeps --workspace --all-targets --all-features
 
       - name: Create github issue for failed action
         uses: imjohnbo/issue-bot@v3


### PR DESCRIPTION
Mark CPU hungry steps of our CI as `nice` so that people who run GitHub self hosted runners on their dev boxen don't suffer.

(This approach is arguably not as elegant in principle, as telling the whole container to run `nice`, but it's a lot simpler to implement than mucking around with the third party container we are using.)