### PR TITLE
ci: skip taplo if cached

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -42,8 +42,9 @@ runs:
     - name: Install nextest
       if: ${{ steps.toolchain-cache-restore.outputs.cache-hit != 'true' }}
       uses: taiki-e/install-action@nextest
-        
+
     - name: Install taplo-cli
+      if: ${{ steps.toolchain-cache-restore.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         cargo install --git https://github.com/tamasfe/taplo taplo-cli


### PR DESCRIPTION
cargo taplo gets cached in the toolchain, so we should skip it if we have a toolchain cache, otherwise [ci gets very sad](https://github.com/0xmozak/mozak-vm/actions/runs/7636920899/job/20804853365)