### PR TITLE
Make env_logger non optional dep

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { version = "1.0", default-features = false }
 bitfield = "0.14"
 derive_more = "0.99"
 elf = { version = "0.7" }
-env_logger = { version = "0.10", optional = true }
+env_logger = { version = "0.10" }
 im = "15.1"
 itertools = "0.12"
 log = "0.4"
@@ -27,7 +27,6 @@ serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-env_logger = { version = "0.10" }
 proptest = "1.4"
 serde_json = "1.0"
 test-case = "3.3"
@@ -39,4 +38,4 @@ name = "fibonacci"
 [features]
 default = ["std", "im/serde"]
 std = ["anyhow/std"]
-test = ["env_logger", "proptest"]
+test = ["proptest"]


### PR DESCRIPTION
While working on wasm related PRs I did changes which this PR reverts. However making env_logger conditional with test feature causes compilation problem for wasm-demo. 