### PR TITLE
Make run_examples detect failure

### DIFF
--- a/run_examples.sh
+++ b/run_examples.sh
@@ -34,11 +34,9 @@ for profile in "${PROFILES[@]}"; do
                 public_iotape="--io-tape-public examples/${member}/iotape_public"
                 ;;
             "merkleproof-trustedroot")
-                host_target=$(rustc --version --verbose | grep 'host' | cut -d ' ' -f2)
-                cargo run --manifest-path=examples/"${bin}"/Cargo.toml --release --features="native" --bin merkleproof-trustedroot-native --target "$host_target"
-
-                private_iotape="--io-tape-private private_input.tape"
-                public_iotape="--io-tape-public public_input.tape"
+                echo "(mozak-cli) skipping (${profile}): ${bin}"
+                skipped="${skipped}${bin} (${profile})\n"
+                continue
                 ;;
 
             esac


### PR DESCRIPTION
`run_examples.sh` uses
```bash
cmd=$(.. some command that runs a test .. )
if [ ! "$cmd" ]; then
```
to try and detect whether the test ran successfully.

Alas, `cmd=$(.. command ..)` assigns the stdout of the command to the
valiable `cmd`.  It does not assign the exit code.

We could use `success=$?` here, but we don't actually need the extra
variable.

Also: stop exiting successfully, just because we skipped any test.

Also: updated the command line argument passing in the script to be compatible with changes in the CLI.

Also: skip `merkleproof-trustedroot` for now, because it's broken.