### PR TITLE
If outputs vec is empty() then halt with 0

### DIFF
--- a/guest/src/env.rs
+++ b/guest/src/env.rs
@@ -17,9 +17,12 @@ pub fn init() {
 #[cfg(target_os = "zkvm")]
 pub fn finalize() {
     unsafe {
-        let output_bytes_vec = OUTPUT_BYTES.as_ref().unwrap_unchecked();
-        let output_0 = output_bytes_vec.first().unwrap_unchecked();
-        mozak_system::system::syscall_halt(*output_0);
+        mozak_system::system::syscall_halt(
+            OUTPUT_BYTES
+                .as_ref()
+                .and_then(|v| v.first().cloned())
+                .unwrap_or_default(),
+        );
     }
 }
 


### PR DESCRIPTION
`unwrap_unchecked()` in `env::finalize()` can result in `UNIMP` in certain case. So this PR remove usage of them.

`UNIMP` is an alias for the `CSRRW` instruction:

> `UNIMP` : `C0001073`. This is an alias for `CSRRW x0, cycle, x0`. Since `cycle` is a read-only CSR, then (whether this CSR exists or not) an attempt to write into it will generate an illegal instruction exception. This 32-bit form of `UNIMP` is emitted when targeting a system without the C extension, or when the `.option norvc` directive is used.