### PR TITLE
Remove obsolete `PackedChallenge`

### DIFF
--- a/circuits3/src/config.rs
+++ b/circuits3/src/config.rs
@@ -25,7 +25,6 @@ pub trait Mozak3StarkConfig {
     const CHUNK: usize;
     type Val;
     type Challenge;
-    type PackedChallenge;
     type Pcs;
     type Challenger;
     type Perm;
@@ -54,7 +53,6 @@ impl Mozak3StarkConfig for DefaultConfig {
     type MyCompress = TruncatedPermutation<Self::Perm, 2, { Self::CHUNK }, { Self::WIDTH }>;
     type MyConfig = StarkConfig<Self::Val, Self::Challenge, Self::Pcs, Self::Challenger>;
     type MyHash = SerializingHasher64<Keccak256Hash>;
-    type PackedChallenge = BinomialExtensionField<<Self::Val as Field>::Packing, { Self::D }>;
     type Pcs = TwoAdicFriPcs<
         TwoAdicFriPcsConfig<
             Self::Val,
@@ -116,7 +114,6 @@ impl Mozak3StarkConfig for BabyBearConfig {
     type MyCompress = TruncatedPermutation<Self::Perm, 2, { Self::CHUNK }, { Self::WIDTH }>;
     type MyConfig = StarkConfig<Self::Val, Self::Challenge, Self::Pcs, Self::Challenger>;
     type MyHash = SerializingHasher32<Keccak256Hash>;
-    type PackedChallenge = BinomialExtensionField<<Self::Val as Field>::Packing, { Self::D }>;
     type Pcs = TwoAdicFriPcs<
         TwoAdicFriPcsConfig<
             Self::Val,


### PR DESCRIPTION
`PackedChallenge` was removed from plonky3 recently.

See https://github.com/Plonky3/Plonky3/pull/258