### PR TITLE
Suppress warning

### DIFF
--- a/examples/bss-tester/main.rs
+++ b/examples/bss-tester/main.rs
@@ -6,6 +6,7 @@ use core::assert_eq;
 // ref: https://stackoverflow.com/questions/40465933/how-do-i-write-rust-code-that-places-globals-statics-in-a-populated-bss-segmen
 static mut XYZ: [u8; 20] = [51; 20];
 
+#[allow(static_mut_ref)]
 pub fn main() {
     unsafe {
         assert_eq!(XYZ[2], 51);


### PR DESCRIPTION
We are running single-threaded, so it's fine.

And we don't want to be distracted by this warning, when looking at other warnings.