### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/ci-deps/action.yml
+++ b/.github/actions/ci-deps/action.yml
@@ -29,9 +29,7 @@ runs:
     - name: Install CI deps
       shell: bash
       run: |
-        # Remove previously installed nix profiles
-        nix profile remove '.*'
-        # Install the current one
+        # Install CI deps
         nix profile install .#ci-deps
         # Set up CI environment
         nix run .#ci-env >> $GITHUB_ENV

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
         };
 
         # CI Setup for GitHub Actions
-        packages.ci-env = pkgs.writeScriptBin "ci-setup" ''
+        packages.ci-env = pkgs.writeShellScriptBin "ci-setup" ''
           echo CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-args=-Wl,-rpath,${config.packages.ci-deps}/lib/"
           echo CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-args=-Wl,-rpath,${config.packages.ci-deps}/lib/"
         '';


### PR DESCRIPTION
- do not remove existing profiles; `.#ci-deps` profile will overwrite
  previously installed profile on `nix profile install`.
- use `writeShellScriptBin` to include the shebang line in the generated
  script.