### PR TITLE
Allow for cross-platform docker build

### DIFF
--- a/mozak-runner/Dockerfile
+++ b/mozak-runner/Dockerfile
@@ -10,8 +10,7 @@ RUN curl --proto '=https' \
   | sh -s -- \
   install linux \
   --extra-conf "sandbox = false" \
-  # TODO: Build it on amd64
-  # --extra-conf "filter-syscalls = false" \
+  --extra-conf "filter-syscalls = false" \
   # Do nothing as we will manually start the nix daemon
   --init none \
   --no-confirm


### PR DESCRIPTION
By default nix traps syscalls.  However this breaks when building/running containers under emulation.  Therefore we need to disable it, if we want to build the image from a different platform.

See a relevant thread on NixOS discourse:
https://discourse.nixos.org/t/cross-compilation-failing-with-nix-and-docker-on-macos/22169/4