### PR TITLE
ci: switch back to public taplo

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Install taplo-cli
       shell: bash
       run: |
-        cargo install --force --git https://github.com/Daniel-Aaron-Bloom/taplo taplo-cli --no-default-features
+        cargo install --force --git https://github.com/tamasfe/taplo taplo-cli --no-default-features
 
     - id: toolchain-cache-save
       name: Cache Rust toolchain (Local Save)


### PR DESCRIPTION
https://github.com/tamasfe/taplo/pull/565 is merged so we can revert back to mainline.