### PR TITLE
refactor: cleanup a lot of duplicate recproof code

### DIFF
--- a/circuits/benches/recproof.rs
+++ b/circuits/benches/recproof.rs
@@ -25,8 +25,8 @@ impl DummyLeafCircuit {
     pub fn new(circuit_config: &CircuitConfig) -> Self {
         let mut builder = CircuitBuilder::<F, D>::new(circuit_config.clone());
 
-        let make_tree_inputs = make_tree::LeafInputs::default(&mut builder);
-        let make_tree_targets = make_tree_inputs.build(&mut builder);
+        let make_tree_inputs = make_tree::SubCircuitInputs::default(&mut builder);
+        let make_tree_targets = make_tree_inputs.build_leaf(&mut builder);
 
         let (circuit, unbounded) = unbounded::LeafSubCircuit::new(builder);
         let make_tree = make_tree_targets.build(&circuit.prover_only.public_inputs);
@@ -71,9 +71,9 @@ impl DummyBranchCircuit {
         let left_proof = builder.add_virtual_proof_with_pis(common);
         let right_proof = builder.add_virtual_proof_with_pis(common);
 
-        let make_tree_inputs = make_tree::BranchInputs::default(&mut builder);
+        let make_tree_inputs = make_tree::SubCircuitInputs::default(&mut builder);
         let make_tree_targets =
-            make_tree_inputs.build(&mut builder, &leaf.make_tree, &left_proof, &right_proof);
+            make_tree_inputs.build_branch(&mut builder, &leaf.make_tree, &left_proof, &right_proof);
 
         let (circuit, unbounded) = unbounded::BranchSubCircuit::new(
             builder,

--- a/circuits/src/recproof/mod.rs
+++ b/circuits/src/recproof/mod.rs
@@ -211,3 +211,28 @@ fn at_least_one_true<F, const D: usize>(
     // If all booleans were 0, self-division will be unsatisfiable
     builder.div(total, total);
 }
+
+/// Finds the index of a target `t` in an array. Useful for getting and
+/// labelling the indicies for public inputs.
+fn find_target(targets: &[Target], t: Target) -> usize {
+    targets
+        .iter()
+        .position(|&pi| pi == t)
+        .expect("target not found")
+}
+
+/// Finds the index of a boolean target `t` in an array. Useful for getting and
+/// labelling the indicies for public inputs.
+fn find_bool(targets: &[Target], t: BoolTarget) -> usize { find_target(targets, t.target) }
+
+/// Finds the indices of targets `ts` in an array. Useful for getting and
+/// labelling the indicies for public inputs.
+fn find_targets<const N: usize>(targets: &[Target], ts: [Target; N]) -> [usize; N] {
+    ts.map(|t| find_target(targets, t))
+}
+
+/// Finds the indices of the target elements of `ts` in an array. Useful for
+/// getting and labelling the indicies for public inputs.
+fn find_hash(targets: &[Target], ts: HashOutTarget) -> [usize; NUM_HASH_OUT_ELTS] {
+    find_targets(targets, ts.elements)
+}

--- a/circuits/src/recproof/verify_address.rs
+++ b/circuits/src/recproof/verify_address.rs
@@ -14,6 +14,8 @@ use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::proof::ProofWithPublicInputsTarget;
 
+use super::{find_bool, find_target};
+
 #[derive(Copy, Clone)]
 pub struct PublicIndices {
     pub node_present: usize,
@@ -96,14 +98,8 @@ impl LeafTargets {
     #[must_use]
     pub fn build(self, public_inputs: &[Target]) -> LeafSubCircuit {
         let indices = PublicIndices {
-            node_present: public_inputs
-                .iter()
-                .position(|&pi| pi == self.node_present.target)
-                .expect("target not found"),
-            node_address: public_inputs
-                .iter()
-                .position(|&pi| pi == self.node_address)
-                .expect("target not found"),
+            node_present: find_bool(public_inputs, self.node_present),
+            node_address: find_target(public_inputs, self.node_address),
         };
         LeafSubCircuit {
             targets: self,
@@ -274,14 +270,8 @@ pub struct BranchSubCircuit {
 impl BranchTargets {
     fn get_indices(&self, public_inputs: &[Target]) -> PublicIndices {
         PublicIndices {
-            node_present: public_inputs
-                .iter()
-                .position(|&pi| pi == self.node_present.target)
-                .expect("target not found"),
-            node_address: public_inputs
-                .iter()
-                .position(|&pi| pi == self.node_address)
-                .expect("target not found"),
+            node_present: find_bool(public_inputs, self.node_present),
+            node_address: find_target(public_inputs, self.node_address),
         }
     }
 


### PR DESCRIPTION
Reduces the number of duplicated structure definitions based on @sai-deng's feedback on other PRs.

Main thing is removing `LeafInputs` and `BranchInputs` in favor of `SubCircuitInputs`, and reusing that structure where possible (e.g. in the `*Targets`).

Also added some helpers (`find_hash`, `find_bool`, etc.) to cleanup `PublicIndices` construction.