### PR TITLE
refactor: rename set_intputs to set_witness

### DIFF
--- a/circuits/benches/recproof.rs
+++ b/circuits/benches/recproof.rs
@@ -45,8 +45,8 @@ impl DummyLeafCircuit {
         branch: &DummyBranchCircuit,
     ) -> Result<ProofWithPublicInputs<F, C, D>> {
         let mut inputs = PartialWitness::new();
-        self.make_tree.set_inputs(&mut inputs, present, leaf_value);
-        self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+        self.make_tree.set_witness(&mut inputs, present, leaf_value);
+        self.unbounded.set_witness(&mut inputs, &branch.circuit);
         self.circuit.prove(inputs)
     }
 }
@@ -107,7 +107,7 @@ impl DummyBranchCircuit {
         right_proof: &ProofWithPublicInputs<F, C, D>,
     ) -> Result<ProofWithPublicInputs<F, C, D>> {
         let mut inputs = PartialWitness::new();
-        self.make_tree.set_inputs(&mut inputs, hash, leaf_value);
+        self.make_tree.set_witness(&mut inputs, hash, leaf_value);
         inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
         inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
         self.circuit.prove(inputs)

--- a/circuits/src/recproof/make_tree.rs
+++ b/circuits/src/recproof/make_tree.rs
@@ -113,7 +113,7 @@ impl LeafTargets {
 
 impl LeafSubCircuit {
     /// Get ready to generate a proof
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         present: bool,
@@ -124,10 +124,10 @@ impl LeafSubCircuit {
         } else {
             HashOut::default()
         };
-        self.set_inputs_unsafe(inputs, hash, leaf_value);
+        self.set_witness_unsafe(inputs, hash, leaf_value);
     }
 
-    pub fn set_inputs_unsafe<F: RichField>(
+    pub fn set_witness_unsafe<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         hash: HashOut<F>,
@@ -227,7 +227,7 @@ impl BranchTargets {
 }
 
 impl BranchSubCircuit {
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         hash: HashOut<F>,
@@ -281,8 +281,8 @@ mod test {
             branch: &DummyBranchCircuit,
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.make_tree.set_inputs(&mut inputs, present, leaf_value);
-            self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+            self.make_tree.set_witness(&mut inputs, present, leaf_value);
+            self.unbounded.set_witness(&mut inputs, &branch.circuit);
             self.circuit.prove(inputs)
         }
 
@@ -294,8 +294,8 @@ mod test {
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
             self.make_tree
-                .set_inputs_unsafe(&mut inputs, hash, leaf_value);
-            self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+                .set_witness_unsafe(&mut inputs, hash, leaf_value);
+            self.unbounded.set_witness(&mut inputs, &branch.circuit);
             self.circuit.prove(inputs)
         }
     }
@@ -360,7 +360,7 @@ mod test {
             right_proof: &ProofWithPublicInputs<F, C, D>,
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.make_tree.set_inputs(&mut inputs, hash, leaf_value);
+            self.make_tree.set_witness(&mut inputs, hash, leaf_value);
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
             self.circuit.prove(inputs)

--- a/circuits/src/recproof/merge.rs
+++ b/circuits/src/recproof/merge.rs
@@ -133,7 +133,7 @@ impl LeafTargets {
 }
 
 impl LeafSubCircuit {
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         a_hash: HashOut<F>,
@@ -229,7 +229,7 @@ impl BranchTargets {
 }
 
 impl BranchSubCircuit {
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         a_hash: HashOut<F>,
@@ -289,8 +289,8 @@ mod test {
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
             self.merge
-                .set_inputs(&mut inputs, a_tree, b_tree, merged_hash);
-            self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+                .set_witness(&mut inputs, a_tree, b_tree, merged_hash);
+            self.unbounded.set_witness(&mut inputs, &branch.circuit);
             self.circuit.prove(inputs)
         }
     }
@@ -351,7 +351,7 @@ mod test {
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
             self.merge
-                .set_inputs(&mut inputs, a_tree, b_tree, merged_hash);
+                .set_witness(&mut inputs, a_tree, b_tree, merged_hash);
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
             self.circuit.prove(inputs)

--- a/circuits/src/recproof/state_from_event.rs
+++ b/circuits/src/recproof/state_from_event.rs
@@ -466,13 +466,13 @@ impl LeafSubCircuit {
         event_ty: EventType,
         event_value: [F; 4],
     ) {
-        self.set_inputs_unsafe(
+        self.set_witness_unsafe(
             witness,
             LeafWitnessValue::from_event(address, event_owner, event_ty, event_value),
         );
     }
 
-    pub fn set_inputs_unsafe<F: RichField>(
+    pub fn set_witness_unsafe<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         v: LeafWitnessValue<F>,
@@ -819,7 +819,7 @@ mod test {
                 event_ty,
                 event_value,
             );
-            self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+            self.unbounded.set_witness(&mut inputs, &branch.circuit);
             self.circuit.prove(inputs)
         }
 
@@ -830,8 +830,8 @@ mod test {
             v: LeafWitnessValue<F>,
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.state_from_events.set_inputs_unsafe(&mut inputs, v);
-            self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+            self.state_from_events.set_witness_unsafe(&mut inputs, v);
+            self.unbounded.set_witness(&mut inputs, &branch.circuit);
             self.circuit.prove(inputs)
         }
     }

--- a/circuits/src/recproof/state_update.rs
+++ b/circuits/src/recproof/state_update.rs
@@ -95,10 +95,10 @@ where
         address: Option<u64>,
     ) -> Result<ProofWithPublicInputs<F, C, D>> {
         let mut inputs = PartialWitness::new();
-        self.summarized.set_inputs(&mut inputs, summary_hash);
-        self.old.set_inputs(&mut inputs, old_hash);
-        self.new.set_inputs(&mut inputs, new_hash);
-        self.address.set_inputs(&mut inputs, address);
+        self.summarized.set_witness(&mut inputs, summary_hash);
+        self.old.set_witness(&mut inputs, old_hash);
+        self.new.set_witness(&mut inputs, new_hash);
+        self.address.set_witness(&mut inputs, address);
         self.circuit.prove(inputs)
     }
 }
@@ -237,12 +237,12 @@ where
         let mut inputs = PartialWitness::new();
         inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
         inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
-        self.summarized.set_inputs(&mut inputs, summary_hash);
-        self.old.set_inputs(&mut inputs, old_hash);
-        self.new.set_inputs(&mut inputs, new_hash);
+        self.summarized.set_witness(&mut inputs, summary_hash);
+        self.old.set_witness(&mut inputs, old_hash);
+        self.new.set_witness(&mut inputs, new_hash);
         match address.into() {
-            AddressPresent::Present(a) => self.address.set_inputs(&mut inputs, Some(a)),
-            AddressPresent::Absent => self.address.set_inputs(&mut inputs, None),
+            AddressPresent::Present(a) => self.address.set_witness(&mut inputs, Some(a)),
+            AddressPresent::Absent => self.address.set_witness(&mut inputs, None),
             AddressPresent::Implicit => {}
         }
         self.circuit.prove(inputs)

--- a/circuits/src/recproof/summarized.rs
+++ b/circuits/src/recproof/summarized.rs
@@ -107,15 +107,15 @@ impl LeafTargets {
 }
 
 impl LeafSubCircuit {
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         summary_hash: HashOut<F>,
     ) {
-        self.set_inputs_unsafe(inputs, summary_hash != HashOut::ZERO, summary_hash);
+        self.set_witness_unsafe(inputs, summary_hash != HashOut::ZERO, summary_hash);
     }
 
-    fn set_inputs_unsafe<F: RichField>(
+    fn set_witness_unsafe<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         summary_hash_present: bool,
@@ -249,15 +249,15 @@ impl BranchTargets {
 }
 
 impl BranchSubCircuit {
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         summary_hash: HashOut<F>,
     ) {
-        self.set_inputs_unsafe(inputs, summary_hash != HashOut::ZERO, summary_hash);
+        self.set_witness_unsafe(inputs, summary_hash != HashOut::ZERO, summary_hash);
     }
 
-    fn set_inputs_unsafe<F: RichField>(
+    fn set_witness_unsafe<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         summary_hash_present: bool,
@@ -304,7 +304,7 @@ mod test {
 
         pub fn prove(&self, summary_hash: HashOut<F>) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.summarized.set_inputs(&mut inputs, summary_hash);
+            self.summarized.set_witness(&mut inputs, summary_hash);
             self.circuit.prove(inputs)
         }
 
@@ -315,7 +315,7 @@ mod test {
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
             self.summarized
-                .set_inputs_unsafe(&mut inputs, summary_hash_present, summary_hash);
+                .set_witness_unsafe(&mut inputs, summary_hash_present, summary_hash);
             self.circuit.prove(inputs)
         }
     }
@@ -409,7 +409,7 @@ mod test {
             let mut inputs = PartialWitness::new();
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
-            self.summarized.set_inputs(&mut inputs, summary_hash);
+            self.summarized.set_witness(&mut inputs, summary_hash);
             self.circuit.prove(inputs)
         }
 
@@ -424,7 +424,7 @@ mod test {
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
             self.summarized
-                .set_inputs_unsafe(&mut inputs, summary_hash_present, summary_hash);
+                .set_witness_unsafe(&mut inputs, summary_hash_present, summary_hash);
             self.circuit.prove(inputs)
         }
     }

--- a/circuits/src/recproof/unbounded.rs
+++ b/circuits/src/recproof/unbounded.rs
@@ -95,7 +95,7 @@ impl LeafSubCircuit {
     }
 
     /// Get ready to generate a proof
-    pub fn set_inputs<F, C, const D: usize>(
+    pub fn set_witness<F, C, const D: usize>(
         &self,
         inputs: &mut PartialWitness<F>,
         branch: &CircuitData<F, C, D>,
@@ -133,23 +133,9 @@ impl BranchSubCircuit {
         // Connect previous verifier data to current one. This guarantees that every
         // proof in the cycle uses the same verifier data.
         let left_verifier = from_slice::<F, D>(&left_proof.public_inputs, &leaf.common);
-        builder.connect_hashes(
-            left_verifier.circuit_digest,
-            verifier_data_target.circuit_digest,
-        );
-        builder.connect_merkle_caps(
-            &left_verifier.constants_sigmas_cap,
-            &verifier_data_target.constants_sigmas_cap,
-        );
         let right_verifier = from_slice::<F, D>(&left_proof.public_inputs, &leaf.common);
-        builder.connect_hashes(
-            right_verifier.circuit_digest,
-            verifier_data_target.circuit_digest,
-        );
-        builder.connect_merkle_caps(
-            &right_verifier.constants_sigmas_cap,
-            &verifier_data_target.constants_sigmas_cap,
-        );
+        builder.connect_verifier_data(&verifier_data_target, &left_verifier);
+        builder.connect_verifier_data(&verifier_data_target, &right_verifier);
 
         let left_verifier = select_verifier(
             &mut builder,
@@ -209,7 +195,7 @@ mod test {
 
         pub fn prove(&self, branch: &DummyBranchCircuit) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.unbounded.set_inputs(&mut inputs, &branch.circuit);
+            self.unbounded.set_witness(&mut inputs, &branch.circuit);
             self.circuit.prove(inputs)
         }
     }

--- a/circuits/src/recproof/unpruned.rs
+++ b/circuits/src/recproof/unpruned.rs
@@ -91,7 +91,7 @@ impl LeafTargets {
 
 impl LeafSubCircuit {
     /// Get ready to generate a proof
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         unpruned_hash: HashOut<F>,
@@ -215,7 +215,7 @@ impl BranchTargets {
 
 impl BranchSubCircuit {
     /// Get ready to generate a proof
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         unpruned_hash: HashOut<F>,
@@ -254,7 +254,7 @@ mod test {
 
         pub fn prove(&self, unpruned_hash: HashOut<F>) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.unpruned.set_inputs(&mut inputs, unpruned_hash);
+            self.unpruned.set_witness(&mut inputs, unpruned_hash);
             self.circuit.prove(inputs)
         }
     }
@@ -345,7 +345,7 @@ mod test {
             let mut inputs = PartialWitness::new();
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
-            self.unpruned.set_inputs(&mut inputs, unpruned_hash);
+            self.unpruned.set_witness(&mut inputs, unpruned_hash);
             self.circuit.prove(inputs)
         }
     }

--- a/circuits/src/recproof/verify_address.rs
+++ b/circuits/src/recproof/verify_address.rs
@@ -109,15 +109,15 @@ impl LeafTargets {
 }
 
 impl LeafSubCircuit {
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         node_address: Option<u64>,
     ) {
-        self.set_inputs_unsafe(inputs, node_address.is_some(), node_address);
+        self.set_witness_unsafe(inputs, node_address.is_some(), node_address);
     }
 
-    fn set_inputs_unsafe<F: RichField>(
+    fn set_witness_unsafe<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         node_present: bool,
@@ -302,15 +302,15 @@ impl BranchSubCircuit {
     /// This call is actually totally unnecessary, as the parent will
     /// be calculated from the child proofs, but it can be used to verify
     /// the parent is what you think it is.
-    pub fn set_inputs<F: RichField>(
+    pub fn set_witness<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         node_address: Option<u64>,
     ) {
-        self.set_inputs_unsafe(inputs, node_address.is_some(), node_address);
+        self.set_witness_unsafe(inputs, node_address.is_some(), node_address);
     }
 
-    fn set_inputs_unsafe<F: RichField>(
+    fn set_witness_unsafe<F: RichField>(
         &self,
         inputs: &mut PartialWitness<F>,
         node_present: bool,
@@ -352,7 +352,7 @@ mod test {
 
         pub fn prove(&self, node_address: Option<u64>) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
-            self.address.set_inputs(&mut inputs, node_address);
+            self.address.set_witness(&mut inputs, node_address);
             self.circuit.prove(inputs)
         }
 
@@ -363,7 +363,7 @@ mod test {
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
             self.address
-                .set_inputs_unsafe(&mut inputs, node_present, node_address);
+                .set_witness_unsafe(&mut inputs, node_present, node_address);
             self.circuit.prove(inputs)
         }
     }
@@ -453,7 +453,7 @@ mod test {
             let mut inputs = PartialWitness::new();
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
-            self.address.set_inputs(&mut inputs, node_address);
+            self.address.set_witness(&mut inputs, node_address);
             self.circuit.prove(inputs)
         }
 
@@ -468,7 +468,7 @@ mod test {
             inputs.set_proof_with_pis_target(&self.targets.left_proof, left_proof);
             inputs.set_proof_with_pis_target(&self.targets.right_proof, right_proof);
             self.address
-                .set_inputs_unsafe(&mut inputs, node_present, node_address);
+                .set_witness_unsafe(&mut inputs, node_present, node_address);
             self.circuit.prove(inputs)
         }
     }


### PR DESCRIPTION
Also use `connect_verifier_data` instead of `connect_merkle_caps`