### PR TITLE
ci+fix: fix nix healthcheck throttle by adding PAT

### DIFF
--- a/mozak-runner/compose.yaml
+++ b/mozak-runner/compose.yaml
@@ -33,6 +33,8 @@ services:
     image: 0xmozak/github-runner:latest
     volumes:
       - "nix-store:/nix"
+    environment:
+      NIX_CONFIG: access-tokens = github.com=${ACCESS_TOKEN}
     entrypoint: ["/root/.nix-profile/bin/nix", "daemon"]
     # Check if we can build a small nix package from a known version of nixpkgs
     healthcheck:


### PR DESCRIPTION
I got spurious errors about throttling occasionally from the health check. Using [access tokens](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-access-tokens) should avoid that.