### PR TITLE
Arithmetic operations on collections of columns

### DIFF
--- a/circuits/src/columns_view.rs
+++ b/circuits/src/columns_view.rs
@@ -35,6 +35,13 @@ pub trait NumberOfColumns {
     const NUMBER_OF_COLUMNS: usize;
 }
 
+pub trait Zip<Item> {
+    #[must_use]
+    fn zip_with<F>(self, other: Self, f: F) -> Self
+    where
+        F: FnMut(Item, Item) -> Item;
+}
+
 /// This structure only exists to improve macro impl hiding
 #[doc(hidden)]
 pub struct ColumnViewImplHider<T>(PhantomData<T>);
@@ -101,6 +108,18 @@ macro_rules! columns_view_impl {
             }
         }
 
+        impl<Item> crate::columns_view::Zip<Item> for $s<Item> {
+            fn zip_with<F>(self, other: Self, mut f: F) -> Self
+            where
+                F: FnMut(Item, Item) -> Item, {
+                $s::from_array({
+                    let mut a = self.into_iter();
+                    let mut b = other.into_iter();
+                    core::array::from_fn(move |_| f(a.next().unwrap(), b.next().unwrap()))
+                })
+            }
+        }
+
         impl<T> crate::columns_view::NumberOfColumns for $s<T> {
             // `u8` is guaranteed to have a `size_of` of 1.
             const NUMBER_OF_COLUMNS: usize = std::mem::size_of::<$s<u8>>();
@@ -155,6 +174,44 @@ macro_rules! columns_view_impl {
                 let vec: arrayvec::ArrayVec<T, LEN> = iter.into_iter().collect();
                 let array = vec.into_inner().expect("iterator of correct length");
                 Self::from_array(array)
+            }
+        }
+        impl core::ops::Neg for $s<i64> {
+            type Output = Self;
+
+            fn neg(self) -> Self::Output {
+                self.map(|x| x.checked_neg().expect("negation overflow"))
+            }
+        }
+        impl core::ops::Add<$s<i64>> for $s<i64> {
+            type Output = Self;
+
+            fn add(self, other: Self) -> Self::Output {
+                crate::columns_view::Zip::zip_with(self, other, |a, b| {
+                    a.checked_add(b).expect("addition overflow")
+                })
+            }
+        }
+        impl core::ops::Sub<$s<i64>> for $s<i64> {
+            type Output = Self;
+
+            fn sub(self, other: Self) -> Self::Output {
+                crate::columns_view::Zip::zip_with(self, other, |a, b| {
+                    a.checked_sub(b).expect("subtraction overflow")
+                })
+            }
+        }
+        impl core::ops::Mul<i64> for $s<i64> {
+            type Output = Self;
+
+            fn mul(self, other: i64) -> Self::Output {
+                self.map(|x| x.checked_mul(other).expect("multiplication overflow"))
+            }
+        }
+        impl core::iter::Sum<$s<i64>> for $s<i64> {
+            #[inline]
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::default(), core::ops::Add::add)
             }
         }
     };

--- a/circuits/src/poseidon2_sponge/columns.rs
+++ b/circuits/src/poseidon2_sponge/columns.rs
@@ -1,9 +1,8 @@
 use core::ops::Add;
 
-use plonky2::hash::hash_types::RichField;
 #[cfg(feature = "enable_poseidon_starks")]
 use plonky2::hash::hash_types::NUM_HASH_OUT_ELTS;
-use plonky2::hash::poseidon2::{Poseidon2, WIDTH};
+use plonky2::hash::poseidon2::WIDTH;
 
 use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
 #[cfg(feature = "enable_poseidon_starks")]
@@ -19,7 +18,7 @@ pub struct Ops<T> {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Default, Eq, PartialEq, Debug)]
 pub struct Poseidon2Sponge<T> {
     pub clk: T,
     pub ops: Ops<T>,
@@ -29,21 +28,6 @@ pub struct Poseidon2Sponge<T> {
     pub preimage: [T; WIDTH],
     pub output: [T; WIDTH],
     pub gen_output: T,
-}
-
-impl<F: RichField> Default for Poseidon2Sponge<F> {
-    fn default() -> Self {
-        Self {
-            clk: F::default(),
-            ops: Ops::<F>::default(),
-            input_addr: F::default(),
-            input_len: F::default(),
-            output_addr: F::default(),
-            preimage: [F::default(); WIDTH],
-            output: <F as Poseidon2>::poseidon2([F::default(); WIDTH]),
-            gen_output: F::default(),
-        }
-    }
 }
 
 columns_view_impl!(Poseidon2Sponge);


### PR DESCRIPTION
Peeled off from https://github.com/0xmozak/mozak-vm/pull/1371

For `Sum` we need `Default`, so for simplicity we change the default for `Poseidon2Sponge` to be all zeros.