### PR TITLE
Switch to using `nixdo` instead of `nix profile install`

### DIFF
--- a/.github/actions/ci-deps/action.yml
+++ b/.github/actions/ci-deps/action.yml
@@ -26,19 +26,21 @@ runs:
     - name: Set up Nix cache
       uses: DeterminateSystems/magic-nix-cache-action@v3
 
-    - name: Install CI deps
+    - name: Cleanup of past installations of .ci-deps
       shell: bash
       run: |
-        # Install CI deps
-        nix profile install .#ci-deps
-        # Set up CI environment
-        nix run .#ci-env >> $GITHUB_ENV
+        nix profile remove '.*ci-deps.*'
+
+    - name: Install nixdo
+      shell: bash
+      run: |
+        echo "$PWD/scripts" >> $GITHUB_PATH
 
     - id: get-info
       name: Get info
       shell: bash
       run: |
-        RUST_VERSION="$(taplo get -f rust-toolchain.toml 'toolchain.channel')"
+        RUST_VERSION="$(nixdo taplo get -f rust-toolchain.toml 'toolchain.channel')"
         echo "cache-primary-key=toolchain-${{ runner.os }}-${{ runner.arch }}-${RUST_VERSION}" >> "$GITHUB_OUTPUT"
 
     - id: toolchain-cache-restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compile and archive all the tests
-        run: nice cargo nextest archive --cargo-profile="${{ matrix.profile }}" --locked --features="enable_poseidon_starks" --all-targets --archive-file mozak-vm-tests.tar.zst
+        run: nixdo nice cargo nextest archive --cargo-profile="${{ matrix.profile }}" --locked --features="enable_poseidon_starks" --all-targets --archive-file mozak-vm-tests.tar.zst
 
       - name: Run all the tests from the archive
-        run: MOZAK_STARK_DEBUG=true nice cargo nextest run --no-fail-fast --archive-file mozak-vm-tests.tar.zst
+        run: nixdo MOZAK_STARK_DEBUG=true nice cargo nextest run --no-fail-fast --archive-file mozak-vm-tests.tar.zst
   
   sdk-sanity:
     needs: check-runner
@@ -67,30 +67,30 @@ jobs:
       - name: cargo-clippy (mozakvm)
         working-directory: sdk
         run: |
-          cargo clippy --locked --all-features -- -D warnings
+          nixdo cargo clippy --locked --all-features -- -D warnings
 
       - name: cargo-clippy (native)
         working-directory: sdk
         run: |
-          ARCH_TRIPLE="$(rustc --verbose --version | grep host | awk '{ print $2; }')"
-          cargo clippy --locked --target $ARCH_TRIPLE --all-features -- -D warnings
+          ARCH_TRIPLE="$(nixdo rustc --verbose --version | grep host | awk '{ print $2; }')"
+          nixdo cargo clippy --locked --target $ARCH_TRIPLE --all-features -- -D warnings
 
       - name: Build (mozakvm)
         working-directory: sdk
         run: |
-          cargo check --locked
+          nixdo cargo check --locked
 
       - name: Build (native)
         working-directory: sdk
         run: |
-          ARCH_TRIPLE="$(rustc --verbose --version | grep host | awk '{ print $2; }')"
-          cargo check --locked --target $ARCH_TRIPLE
+          ARCH_TRIPLE="$(nixdo rustc --verbose --version | grep host | awk '{ print $2; }')"
+          nixdo cargo check --locked --target $ARCH_TRIPLE
 
       - name: Test library
         working-directory: sdk
         run: |
-          ARCH_TRIPLE="$(rustc --verbose --version | grep host | awk '{ print $2; }')"
-          cargo test --locked --lib --target $ARCH_TRIPLE
+          ARCH_TRIPLE="$(nixdo rustc --verbose --version | grep host | awk '{ print $2; }')"
+          nixdo cargo test --locked --lib --target $ARCH_TRIPLE
 
   run-examples:
     needs: check-runner
@@ -106,8 +106,8 @@ jobs:
 
       - name: Build and run examples
         run: |
-          cd examples && nice cargo build --release
-          cd .. && nice ./run_examples.sh
+          cd examples && nixdo nice cargo build --release
+          cd .. && nixdo nice ./run_examples.sh
 
   cargo-clippy:
     needs: check-runner
@@ -122,7 +122,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Clippy linter
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        run: nixdo cargo clippy --all-features --all-targets -- -D warnings
 
   cargo-build-examples:
     needs: check-runner
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build all examples
         run: |
-          cd examples-builder && cargo build --all-features
+          cd examples-builder && nixdo cargo build --all-features
 
   cargo-fmt:
     needs: check-runner
@@ -153,7 +153,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run fmt
-        run: cargo fmt --all --check
+        run: nixdo cargo fmt --all --check
 
   shellcheck:
     needs: check-runner
@@ -179,4 +179,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: taplo fmt
-        run: taplo fmt --check
+        run: nixdo taplo fmt --check

--- a/scripts/nixdo
+++ b/scripts/nixdo
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Run arguments inside the default devShell
+nix develop --command env "$@"


### PR DESCRIPTION
For simplicity we were installing CI dependencies using `nix profile install`.  However over time such approach has proven troublesome, especially as we have multiple self-hosted runners that share a common nix process.  In such scenario we cannot easily clean up previous `nix profile install` installations, as we might accidentally remove an installation used by a different runner.

Therefore, we are switching to using `nix develop`, which will create a temporary environment per invocation.

The approach is still not ideal, as a dev shell can be potentially garbage collected midway the invocation, but now nix will try to populate the nix store with dependencies for each invocation, preventing collisions when asking jobs to explicitly remove previous installation of `nix profile`.

This PR also includes `nix profile remove '.*ci-deps.*'` to ensure that we remove all previous installations of `ci-deps`.

Finally, we update the `rust-cache` action to a version that can use `nix develop --command rustc` to query the version of Rust compiler.