### PR TITLE
Reproduce bug

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -14,7 +14,7 @@ use crate::memory_io::columns::InputOutputMemoryCtl;
 use crate::poseidon2_sponge::columns::Poseidon2SpongeCtl;
 use crate::program::columns::{InstructionRow, ProgramRom};
 use crate::rangecheck::columns::RangeCheckCtl;
-use crate::stark::mozak_stark::{CpuTable, TableNamed};
+use crate::stark::mozak_stark::{CpuTable, TableNamed, XorTable};
 use crate::xor::columns::XorView;
 
 columns_view_impl!(OpSelectors);
@@ -311,7 +311,7 @@ pub fn rangecheck_looking() -> Vec<TableNamed<RangeCheckCtl<Column>>> {
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
 #[must_use]
 pub fn lookup_for_xor() -> TableNamed<XorView<Column>> {
-    CpuTable::new(CPU_MAP.xor, CPU_MAP.inst.ops.ops_that_use_xor())
+    XorTable::new(CPU_MAP.xor, CPU_MAP.inst.ops.ops_that_use_xor())
 }
 
 /// Lookup into Memory stark.


### PR DESCRIPTION
Use `cargo test --package mozak-circuits --lib -- cpu::add::tests::prove_add_mozak_example --exact --nocapture `

Perhaps add `MOZAK_STARK_DEBUG=true RUST_BACKTRACE=1` before.

You get
```
thread 'cpu::add::tests::prove_add_mozak_example' panicked at circuits/src/linear_combination.rs:61:17:
index out of bounds: the len is 100 but the index is 100
```
instead of a proper error message.  And that's because we are lucky, if I had 'accidentally' mixed up things in the other direction, we wouldn't even have gotten an out-of-bounds error.