### PR TITLE
Refactor for typed linear combinations

### DIFF
--- a/circuits/src/linear_combination_typed.rs
+++ b/circuits/src/linear_combination_typed.rs
@@ -20,12 +20,15 @@ pub struct ColumnWithTypedInput<InputColumns> {
     pub constant: i64,
 }
 
-/// Flip lv and nv
-pub fn flip<C>(col: ColumnWithTypedInput<C>) -> ColumnWithTypedInput<C> {
-    ColumnWithTypedInput {
-        lv_linear_combination: col.nv_linear_combination,
-        nv_linear_combination: col.lv_linear_combination,
-        constant: col.constant,
+impl<InputColumns> ColumnWithTypedInput<InputColumns> {
+    /// Flip lv and nv
+    #[must_use]
+    pub fn flip(self) -> Self {
+        ColumnWithTypedInput {
+            lv_linear_combination: self.nv_linear_combination,
+            nv_linear_combination: self.lv_linear_combination,
+            constant: self.constant,
+        }
     }
 }
 
@@ -119,6 +122,16 @@ where
 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self { iter.fold(Self::default(), Add::add) }
+}
+
+impl<'a, C: Copy> Sum<&'a Self> for ColumnWithTypedInput<C>
+where
+    Self: Add<Output = Self> + Default,
+{
+    #[inline]
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.copied().fold(Self::default(), Add::add)
+    }
 }
 
 impl<C> ColumnWithTypedInput<C>


### PR DESCRIPTION
To minimize review for https://github.com/0xmozak/mozak-vm/pull/1371

Renames, an implementation of `Sum`, and making `flip` an impl-function.