### PR TITLE
Implement batched inversion for logup

### DIFF
--- a/circuits/src/cross_table_lookup.rs
+++ b/circuits/src/cross_table_lookup.rs
@@ -1,5 +1,5 @@
 use anyhow::{ensure, Result};
-use itertools::{chain, iproduct, izip, zip_eq, Itertools};
+use itertools::{chain, iproduct, izip, zip_eq};
 use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
@@ -170,28 +170,30 @@ fn partial_sums<F: Field>(
     // final value_local, its impossible to construct value_next from lv and nv
     // values of current row
 
-    // TODO(Kapil): inverse for all rows is expensive. Use batched division idea.
+    let get_multiplicity = |&i| -> F { filter_column.eval_table(trace, i) };
 
-    let combine_and_inv_if_filter_at_i = |i| -> F {
-        let multiplicity = filter_column.eval_table(trace, i);
+    let get_combined = |&i| -> F {
         let evals = columns
             .iter()
             .map(|c| c.eval_table(trace, i))
             .collect::<Vec<_>>();
-        multiplicity * challenge.combine(evals.iter()).inverse()
+        challenge.combine(evals.iter())
     };
 
     let degree = trace[0].len();
     let mut degrees = (0..degree).collect::<Vec<_>>();
     degrees.rotate_right(1);
-    degrees
-        .into_iter()
-        .map(combine_and_inv_if_filter_at_i)
-        .scan(F::ZERO, |partial_sum: &mut F, combined| {
-            *partial_sum += combined;
+
+    let multiplicities: Vec<F> = degrees.iter().map(get_multiplicity).collect();
+    let data: Vec<F> = degrees.iter().map(get_combined).collect();
+    let inv_data = F::batch_multiplicative_inverse(&data);
+
+    izip!(multiplicities, inv_data)
+        .scan(F::ZERO, |partial_sum: &mut F, (multiplicity, inv)| {
+            *partial_sum += multiplicity * inv;
             Some(*partial_sum)
         })
-        .collect_vec()
+        .collect::<Vec<_>>()
         .into()
 }
 


### PR DESCRIPTION
On my machine our simple benchmark

```cargo run --features=timing --bin mozak-cli -- bench nop-bench 123456```

goes from about 25s to about 15s.