### PR TITLE
Use self-hosted runners, even when they are busy

### DIFF
--- a/.github/workflows/check-runner.yml
+++ b/.github/workflows/check-runner.yml
@@ -27,10 +27,9 @@ jobs:
               --location "${url}" || echo "")
             echo "${runners}"
 
-            # Filter to self-hosted runners that aren't busy
-            # Note that if a self-hosted runner is running this job, it will be considered 'busy' by GitHub,
-            # but obviously that's not busy by our standards.
-            if echo "${runners}" | jq --exit-status '(.runners // [])[] | select(.status == "online" and (.busy == false or .name == "${{ runner.name }}") and .labels[] .name == "self-hosted")'; then
+            # If any self-hosted runners are online, use them.
+            # Even if they are busy: our self-hosted runners are a lot faster than GitHub's runners.
+            if echo "${runners}" | jq --exit-status '(.runners // [])[] | select(.status == "online" and .labels[] .name == "self-hosted")'; then
               # If we found an available self-hosted runner, then proceed to signal our desire to use self-hosted.
               echo "runner-label=self-hosted" | tee --append "${GITHUB_OUTPUT}"
               exit 0


### PR DESCRIPTION
Our self-hosted runners are generally so much faster than GitHub's runners, that it makes sense to wait for them to become less busy, instead of falling back to GitHub's runners.

However, when no self-hosted runners are online, we still fall back to GitHub's runners.