### PR TITLE
deps: downgrade rkyv from `0.8.0-alpha.2` to `0.8.0-alpha.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,9 +1474,9 @@ checksum = "7f02fc3227b019649985d2f89e254e345f027cc58af7bbf5faa4f3f7271bc4cc"
 
 [[package]]
 name = "rkyv"
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d125265f4bf0016653476f0e6f33757f4d5ce34447473c2b317c1bb28766481"
+checksum = "f11954ea56d7bfee4022704c89d997ca15659bff852ab06dbee5cbeffdc723ed"
 dependencies = [
  "bitvec",
  "hashbrown 0.14.3",
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670836f48c7644bc9f68e507064f0a83984e910a5a5515ac5f496ccf4e109e6b"
+checksum = "5d936536583355d1ef18b9473dbe2a59d0c9ffff278a92c171feb30f2489dd0a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,7 +30,7 @@ env_logger = "0.11"
 itertools = "0.12"
 log = "0.4"
 plonky2 = "0"
-rkyv = { version = "0.8.0-alpha.2", default-features = false, features = ["pointer_width_32", "alloc"] }
+rkyv = { version = "0.8.0-alpha.1", default-features = false, features = ["pointer_width_32", "alloc"] }
 serde_json = "1.0"
 starky = "0"
 tempfile = "3"


### PR DESCRIPTION
Extracted from #1335

This is to unblock #1335, since tx bundling fails most likely due to the mismatch in versions. In `alpha.2`, `rkyv` includes a new `Portable` trait which structs must implement. Source: https://github.com/rkyv/rkyv/commit/45d735af30483663c8052e1750cf4c0b21f7d39f

We can upgrade `rkyv` once `0.8` is out of alpha.