### PR TITLE
fix: Remove all local (stack) copies of massive tables

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -182,7 +182,7 @@ pub struct CpuState<T> {
     pub poseidon2_input_addr: T,
     pub poseidon2_input_len: T,
 }
-pub(crate) const CPU: CpuState<ColumnWithTypedInput<CpuColumnsExtended<i64>>> = COL_MAP.cpu;
+pub(crate) const CPU: &CpuState<ColumnWithTypedInput<CpuColumnsExtended<i64>>> = &COL_MAP.cpu;
 
 make_col_map!(CpuColumnsExtended);
 columns_view_impl!(CpuColumnsExtended);
@@ -269,7 +269,7 @@ pub fn signed_diff_extension_target<F: RichField + Extendable<D>, const D: usize
 /// [`CpuTable`](crate::cross_table_lookup::CpuTable).
 #[must_use]
 pub fn rangecheck_looking() -> Vec<TableWithTypedOutput<RangeCheckCtl<Column>>> {
-    let ops = CPU.inst.ops;
+    let ops = &CPU.inst.ops;
     let divs = ops.div + ops.rem + ops.srl + ops.sra;
     let muls: ColumnWithTypedInput<CpuColumnsExtended<i64>> = ops.mul + ops.mulh + ops.sll;
 

--- a/circuits/src/memory/columns.rs
+++ b/circuits/src/memory/columns.rs
@@ -178,19 +178,17 @@ pub fn is_executed_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
 
 #[must_use]
 pub fn rangecheck_looking() -> Vec<TableWithTypedOutput<RangeCheckCtl<Column>>> {
-    let mem = COL_MAP;
-    [mem.addr, COL_MAP.addr, mem.diff_clk]
+    [COL_MAP.addr, COL_MAP.addr, COL_MAP.diff_clk]
         .into_iter()
-        .map(|addr| MemoryTable::new(RangeCheckCtl(addr), mem.is_executed()))
+        .map(|addr| MemoryTable::new(RangeCheckCtl(addr), COL_MAP.is_executed()))
         .collect()
 }
 
 #[must_use]
 pub fn rangecheck_u8_looking() -> Vec<TableWithTypedOutput<RangeCheckCtl<Column>>> {
-    let mem = COL_MAP;
     vec![MemoryTable::new(
-        RangeCheckCtl(mem.value),
-        mem.is_executed(),
+        RangeCheckCtl(COL_MAP.value),
+        COL_MAP.is_executed(),
     )]
 }
 
@@ -209,30 +207,27 @@ pub struct MemoryCtl<T> {
 /// stark table.
 #[must_use]
 pub fn lookup_for_cpu() -> TableWithTypedOutput<MemoryCtl<Column>> {
-    let mem = COL_MAP;
     MemoryTable::new(
         MemoryCtl {
-            clk: mem.clk,
-            is_store: mem.is_store,
-            is_load: mem.is_load,
-            addr: mem.addr,
-            value: mem.value,
+            clk: COL_MAP.clk,
+            is_store: COL_MAP.is_store,
+            is_load: COL_MAP.is_load,
+            addr: COL_MAP.addr,
+            value: COL_MAP.value,
         },
-        mem.is_store + mem.is_load,
+        COL_MAP.is_store + COL_MAP.is_load,
     )
 }
 
 /// Lookup into `MemoryInit` Table
 #[must_use]
 pub fn lookup_for_memoryinit() -> TableWithTypedOutput<MemoryInitCtl<Column>> {
-    let mem = COL_MAP;
-
     MemoryTable::new(
         MemoryInitCtl {
-            is_writable: mem.is_writable,
-            address: mem.addr,
-            clk: mem.clk,
-            value: mem.value,
+            is_writable: COL_MAP.is_writable,
+            address: COL_MAP.addr,
+            clk: COL_MAP.clk,
+            value: COL_MAP.value,
         },
         COL_MAP.is_init,
     )

--- a/circuits/src/memory_fullword/columns.rs
+++ b/circuits/src/memory_fullword/columns.rs
@@ -49,14 +49,13 @@ pub const NUM_HW_MEM_COLS: usize = FullWordMemory::<()>::NUMBER_OF_COLUMNS;
 /// stark table.
 #[must_use]
 pub fn lookup_for_cpu() -> TableWithTypedOutput<MemoryCtl<Column>> {
-    let mem = COL_MAP;
     FullWordMemoryTable::new(
         MemoryCtl {
-            clk: mem.clk,
-            is_store: mem.ops.is_store,
-            is_load: mem.ops.is_load,
-            value: ColumnWithTypedInput::reduce_with_powers(mem.limbs, 1 << 8),
-            addr: mem.addrs[0],
+            clk: COL_MAP.clk,
+            is_store: COL_MAP.ops.is_store,
+            is_load: COL_MAP.ops.is_load,
+            value: ColumnWithTypedInput::reduce_with_powers(COL_MAP.limbs, 1 << 8),
+            addr: COL_MAP.addrs[0],
         },
         COL_MAP.is_executed(),
     )
@@ -67,14 +66,13 @@ pub fn lookup_for_cpu() -> TableWithTypedOutput<MemoryCtl<Column>> {
 #[must_use]
 pub fn lookup_for_memory_limb(limb_index: usize) -> TableWithTypedOutput<MemoryCtl<Column>> {
     assert!(limb_index < 4, "limb-index can be 0..4");
-    let mem = COL_MAP;
     FullWordMemoryTable::new(
         MemoryCtl {
-            clk: mem.clk,
-            is_store: mem.ops.is_store,
-            is_load: mem.ops.is_load,
-            value: mem.limbs[limb_index],
-            addr: mem.addrs[limb_index],
+            clk: COL_MAP.clk,
+            is_store: COL_MAP.ops.is_store,
+            is_load: COL_MAP.ops.is_load,
+            value: COL_MAP.limbs[limb_index],
+            addr: COL_MAP.addrs[limb_index],
         },
         COL_MAP.is_executed(),
     )

--- a/circuits/src/memory_halfword/columns.rs
+++ b/circuits/src/memory_halfword/columns.rs
@@ -48,14 +48,13 @@ pub const NUM_HW_MEM_COLS: usize = HalfWordMemory::<()>::NUMBER_OF_COLUMNS;
 /// Lookup from CPU table into halfword memory table.
 #[must_use]
 pub fn lookup_for_cpu() -> TableWithTypedOutput<MemoryCtl<Column>> {
-    let mem = COL_MAP;
     HalfWordMemoryTable::new(
         MemoryCtl {
-            clk: mem.clk,
-            is_store: mem.ops.is_store,
-            is_load: mem.ops.is_load,
-            value: ColumnWithTypedInput::reduce_with_powers(mem.limbs, 1 << 8),
-            addr: mem.addrs[0],
+            clk: COL_MAP.clk,
+            is_store: COL_MAP.ops.is_store,
+            is_load: COL_MAP.ops.is_load,
+            value: ColumnWithTypedInput::reduce_with_powers(COL_MAP.limbs, 1 << 8),
+            addr: COL_MAP.addrs[0],
         },
         COL_MAP.is_executed(),
     )
@@ -68,14 +67,13 @@ pub fn lookup_for_memory_limb(limb_index: usize) -> TableWithTypedOutput<MemoryC
         limb_index < 2,
         "limb_index is {limb_index} but it should be in 0..2 range"
     );
-    let mem = COL_MAP;
     HalfWordMemoryTable::new(
         MemoryCtl {
-            clk: mem.clk,
-            is_store: mem.ops.is_store,
-            is_load: mem.ops.is_load,
-            value: mem.limbs[limb_index],
-            addr: mem.addrs[limb_index],
+            clk: COL_MAP.clk,
+            is_store: COL_MAP.ops.is_store,
+            is_load: COL_MAP.ops.is_load,
+            value: COL_MAP.limbs[limb_index],
+            addr: COL_MAP.addrs[limb_index],
         },
         COL_MAP.is_executed(),
     )

--- a/circuits/src/memory_io/columns.rs
+++ b/circuits/src/memory_io/columns.rs
@@ -59,14 +59,13 @@ pub fn lookup_for_cpu(
     kind: TableKind,
     op: i64,
 ) -> TableWithTypedOutput<InputOutputMemoryCtl<Column>> {
-    let mem = COL_MAP;
     TableWithTypedOutput {
         kind,
         columns: InputOutputMemoryCtl {
             op: ColumnWithTypedInput::constant(op),
-            clk: mem.clk,
-            addr: mem.addr,
-            size: mem.size,
+            clk: COL_MAP.clk,
+            addr: COL_MAP.addr,
+            size: COL_MAP.size,
         }
         .into_iter()
         .map(Column::from)
@@ -78,16 +77,14 @@ pub fn lookup_for_cpu(
 /// Lookup into Memory stark table.
 #[must_use]
 pub fn lookup_for_memory(kind: TableKind) -> TableWithTypedOutput<MemoryCtl<Column>> {
-    let mem = COL_MAP;
-
     TableWithTypedOutput {
         kind,
         columns: MemoryCtl {
-            clk: mem.clk,
-            is_store: mem.ops.is_memory_store,
+            clk: COL_MAP.clk,
+            is_store: COL_MAP.ops.is_memory_store,
             is_load: ColumnWithTypedInput::constant(0),
-            value: mem.value,
-            addr: mem.addr,
+            value: COL_MAP.value,
+            addr: COL_MAP.addr,
         }
         .into_iter()
         .map(Column::from)

--- a/circuits/src/memory_zeroinit/columns.rs
+++ b/circuits/src/memory_zeroinit/columns.rs
@@ -18,11 +18,10 @@ pub const NUM_MEMORYINIT_COLS: usize = MemoryZeroInit::<()>::NUMBER_OF_COLUMNS;
 /// Lookup into Memory Table
 #[must_use]
 pub fn lookup_for_memory() -> TableWithTypedOutput<MemoryInitCtl<Column>> {
-    let mem = COL_MAP;
     MemoryZeroInitTable::new(
         MemoryInitCtl {
             is_writable: ColumnWithTypedInput::constant(1),
-            address: mem.addr,
+            address: COL_MAP.addr,
             clk: ColumnWithTypedInput::constant(0),
             value: ColumnWithTypedInput::constant(0),
         },

--- a/circuits/src/memoryinit/columns.rs
+++ b/circuits/src/memoryinit/columns.rs
@@ -44,13 +44,12 @@ where
         MemoryInitCtl<ColumnWithTypedInput<MemoryInit<i64>>>,
         ColumnWithTypedInput<MemoryInit<i64>>,
     ) -> TableWithTypedOutput<MemoryInitCtl<Column>>, {
-    let mem = COL_MAP;
     new(
         MemoryInitCtl {
-            is_writable: mem.is_writable,
-            address: mem.element.address,
+            is_writable: COL_MAP.is_writable,
+            address: COL_MAP.element.address,
             clk: ColumnWithTypedInput::constant(1),
-            value: mem.element.value,
+            value: COL_MAP.element.value,
         },
         COL_MAP.filter,
     )

--- a/circuits/src/poseidon2_output_bytes/columns.rs
+++ b/circuits/src/poseidon2_output_bytes/columns.rs
@@ -66,12 +66,11 @@ pub struct Poseidon2OutputBytesCtl<F> {
 #[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_poseidon2_sponge() -> TableWithTypedOutput<Poseidon2OutputBytesCtl<Column>> {
-    let data = COL_MAP;
     Poseidon2OutputBytesTable::new(
         Poseidon2OutputBytesCtl {
-            clk: data.clk,
-            output_addr: data.output_addr,
-            output_fields: data.output_fields,
+            clk: COL_MAP.clk,
+            output_addr: COL_MAP.output_addr,
+            output_fields: COL_MAP.output_fields,
         },
         COL_MAP.is_executed,
     )
@@ -81,14 +80,13 @@ pub fn lookup_for_poseidon2_sponge() -> TableWithTypedOutput<Poseidon2OutputByte
 #[must_use]
 pub fn lookup_for_output_memory(limb_index: u8) -> TableWithTypedOutput<MemoryCtl<Column>> {
     assert!(limb_index < 32, "limb_index can be 0..31");
-    let data = COL_MAP;
     Poseidon2OutputBytesTable::new(
         MemoryCtl {
-            clk: data.clk,
+            clk: COL_MAP.clk,
             is_store: ColumnWithTypedInput::constant(1),
             is_load: ColumnWithTypedInput::constant(0),
-            value: data.output_bytes[limb_index as usize],
-            addr: data.output_addr + i64::from(limb_index),
+            value: COL_MAP.output_bytes[limb_index as usize],
+            addr: COL_MAP.output_addr + i64::from(limb_index),
         },
         COL_MAP.is_executed,
     )

--- a/circuits/src/poseidon2_sponge/columns.rs
+++ b/circuits/src/poseidon2_sponge/columns.rs
@@ -57,12 +57,11 @@ pub struct Poseidon2SpongeCtl<T> {
 #[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_cpu() -> TableWithTypedOutput<Poseidon2SpongeCtl<Column>> {
-    let sponge = COL_MAP;
     Poseidon2SpongeTable::new(
         Poseidon2SpongeCtl {
-            clk: sponge.clk,
-            input_addr: sponge.input_addr,
-            input_len: sponge.input_len,
+            clk: COL_MAP.clk,
+            input_addr: COL_MAP.input_addr,
+            input_len: COL_MAP.input_len,
         },
         COL_MAP.ops.is_init_permute,
     )
@@ -71,11 +70,10 @@ pub fn lookup_for_cpu() -> TableWithTypedOutput<Poseidon2SpongeCtl<Column>> {
 #[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_poseidon2() -> TableWithTypedOutput<Poseidon2StateCtl<Column>> {
-    let sponge = COL_MAP;
     Poseidon2SpongeTable::new(
         Poseidon2StateCtl {
-            input: sponge.preimage,
-            output: sponge.output,
+            input: COL_MAP.preimage,
+            output: COL_MAP.output,
         },
         COL_MAP.is_executed(),
     )
@@ -88,12 +86,11 @@ pub fn lookup_for_poseidon2() -> TableWithTypedOutput<Poseidon2StateCtl<Column>>
 #[must_use]
 pub fn lookup_for_poseidon2_output_bytes() -> TableWithTypedOutput<Poseidon2OutputBytesCtl<Column>>
 {
-    let sponge = COL_MAP;
     Poseidon2SpongeTable::new(
         Poseidon2OutputBytesCtl {
-            clk: sponge.clk,
-            output_addr: sponge.output_addr,
-            output_fields: sponge.output[..NUM_HASH_OUT_ELTS].try_into().unwrap(),
+            clk: COL_MAP.clk,
+            output_addr: COL_MAP.output_addr,
+            output_fields: COL_MAP.output[..NUM_HASH_OUT_ELTS].try_into().unwrap(),
         },
         COL_MAP.gen_output,
     )
@@ -103,16 +100,14 @@ pub fn lookup_for_poseidon2_output_bytes() -> TableWithTypedOutput<Poseidon2Outp
 #[must_use]
 pub fn lookup_for_input_memory(limb_index: u8) -> TableWithTypedOutput<MemoryCtl<Column>> {
     assert!(limb_index < 8, "limb_index can be 0..7");
-    let sponge = COL_MAP;
-    let ops = COL_MAP.ops;
     Poseidon2SpongeTable::new(
         MemoryCtl {
-            clk: sponge.clk,
+            clk: COL_MAP.clk,
             is_store: ColumnWithTypedInput::constant(0),
             is_load: ColumnWithTypedInput::constant(1),
-            value: sponge.preimage[limb_index as usize],
-            addr: sponge.input_addr + i64::from(limb_index),
+            value: COL_MAP.preimage[limb_index as usize],
+            addr: COL_MAP.input_addr + i64::from(limb_index),
         },
-        ops.is_init_permute + ops.is_permute,
+        COL_MAP.ops.is_init_permute + COL_MAP.ops.is_permute,
     )
 }

--- a/circuits/src/register/columns.rs
+++ b/circuits/src/register/columns.rs
@@ -104,22 +104,20 @@ impl<T: Add<Output = T>> Register<T> {
 #[cfg(feature = "enable_register_starks")]
 #[must_use]
 pub fn lookup_for_register_init() -> TableWithTypedOutput<RegisterInitCtl<Column>> {
-    let reg = COL_MAP;
     RegisterTable::new(
         RegisterInitCtl {
-            addr: reg.addr,
-            value: reg.value,
+            addr: COL_MAP.addr,
+            value: COL_MAP.value,
         },
-        reg.ops.is_init,
+        COL_MAP.ops.is_init,
     )
 }
 
 #[cfg(feature = "enable_register_starks")]
 #[must_use]
 pub fn rangecheck_looking() -> Vec<TableWithTypedOutput<RangeCheckCtl<Column>>> {
-    let ops = COL_MAP.ops;
     vec![RegisterTable::new(
         RangeCheckCtl(COL_MAP.diff_augmented_clk),
-        ops.is_read + ops.is_write,
+        COL_MAP.ops.is_read + COL_MAP.ops.is_write,
     )]
 }

--- a/circuits/src/registerinit/columns.rs
+++ b/circuits/src/registerinit/columns.rs
@@ -37,12 +37,11 @@ pub struct RegisterInitCtl<T> {
 #[cfg(feature = "enable_register_starks")]
 #[must_use]
 pub fn lookup_for_register() -> TableWithTypedOutput<RegisterInitCtl<Column>> {
-    let reg = COL_MAP;
     RegisterInitTable::new(
         RegisterInitCtl {
-            addr: reg.reg_addr,
-            value: reg.value,
+            addr: COL_MAP.reg_addr,
+            value: COL_MAP.value,
         },
-        reg.is_looked_up,
+        COL_MAP.is_looked_up,
     )
 }


### PR DESCRIPTION
This helps with debugging on low opt levels. You'll still have to set `RUST_MIN_STACK=3000000`.