### PR TITLE
refactor+doc: reorder params, fixup comments, and other minor cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "starky"
 version = "0.3.0"
-source = "git+https://github.com/0xmozak/plonky2.git#4312ef9d53297d0bbb3ef844c0db916d4b3cdf95"
+source = "git+https://github.com/0xmozak/plonky2.git#0671307ccb9e75da4b0e7b7377836d039e952683"
 dependencies = [
  "ahash",
  "anyhow",

--- a/circuits/src/recproof/accumulate_event.rs
+++ b/circuits/src/recproof/accumulate_event.rs
@@ -1,3 +1,5 @@
+//! Subcircuits for proving events can be accumulated to a partial object.
+
 use anyhow::Result;
 use plonky2::field::extension::Extendable;
 use plonky2::hash::hash_types::RichField;
@@ -13,9 +15,15 @@ pub struct LeafCircuit<F, C, const D: usize>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>, {
+    /// The recursion subcircuit
     pub unbounded: unbounded::LeafSubCircuit,
+
+    /// The rp-style merkle hash of all event fields
     pub event_hash: unpruned::LeafSubCircuit,
+
+    /// The event-to-state/partial-object translator
     pub partial_state: state_from_event::LeafSubCircuit,
+
     pub circuit: CircuitData<F, C, D>,
 }
 
@@ -85,9 +93,15 @@ pub struct BranchCircuit<F, C, const D: usize>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>, {
+    /// The recursion subcircuit
     pub unbounded: unbounded::BranchSubCircuit<D>,
+
+    /// The rp-style merkle hash of all event fields
     pub event_hash: unpruned::BranchSubCircuit,
+
+    /// The event-to-state/partial-object translator
     pub partial_state: state_from_event::BranchSubCircuit,
+
     pub circuit: CircuitData<F, C, D>,
 }
 

--- a/circuits/src/recproof/unbounded.rs
+++ b/circuits/src/recproof/unbounded.rs
@@ -379,8 +379,8 @@ mod test {
         pub fn prove(
             &self,
             left_is_leaf: bool,
-            right_is_leaf: bool,
             left_proof: &ProofWithPublicInputs<F, C, D>,
+            right_is_leaf: bool,
             right_proof: &ProofWithPublicInputs<F, C, D>,
         ) -> Result<ProofWithPublicInputs<F, C, D>> {
             let mut inputs = PartialWitness::new();
@@ -415,13 +415,13 @@ mod test {
         let leaf_proof = LEAF.prove(&BRANCH)?;
         LEAF.circuit.verify(leaf_proof.clone())?;
 
-        let branch_proof_1 = BRANCH.prove(true, true, &leaf_proof, &leaf_proof)?;
+        let branch_proof_1 = BRANCH.prove(true, &leaf_proof, true, &leaf_proof)?;
         BRANCH.circuit.verify(branch_proof_1.clone())?;
 
-        let branch_proof_2 = BRANCH.prove(true, false, &leaf_proof, &branch_proof_1)?;
+        let branch_proof_2 = BRANCH.prove(true, &leaf_proof, false, &branch_proof_1)?;
         BRANCH.circuit.verify(branch_proof_2.clone())?;
 
-        let branch_proof_3 = BRANCH.prove(false, false, &branch_proof_1, &branch_proof_2)?;
+        let branch_proof_3 = BRANCH.prove(false, &branch_proof_1, false, &branch_proof_2)?;
         BRANCH.circuit.verify(branch_proof_3)?;
 
         Ok(())


### PR DESCRIPTION
ripped out of #1472 to simplify that PR

Basically just moves `*_is_leaf` to be next to its corresponding proof.