### PR TITLE
Enable disabling of rayon

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -23,7 +23,7 @@ mozak-circuits-derive = { path = "./derive" }
 mozak-runner = { path = "../runner" }
 mozak-sdk = { path = "../sdk" }
 plonky2 = { version = "0", default-features = false }
-plonky2_maybe_rayon = { version = "0" }
+plonky2_maybe_rayon = { version = "0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 starky = { version = "0", default-features = false, features = ["std"] }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.12"
 log = "0.4"
 mozak-examples = { path = "../examples-builder", features = ["empty", "fibonacci"] }
 mozak-sdk = { path = "../sdk" }
-plonky2 = "0"
+plonky2 = { version = "0", default-features = false }
 proptest = { version = "1.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 


### PR DESCRIPTION
We need to be careful to not turn on the default features of plonky2 by default.

Follow up to https://github.com/0xmozak/mozak-vm/pull/1480