### PR TITLE
refactor(generation): move poseidon2 generation code

### DIFF
--- a/circuits/src/generation/fullword_memory.rs
+++ b/circuits/src/generation/fullword_memory.rs
@@ -81,8 +81,8 @@ mod tests {
     };
     use crate::generation::memory::generate_memory_trace;
     use crate::generation::memoryinit::generate_memory_init_trace;
-    use crate::generation::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
+    use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::test_utils::{inv, prep_table};
 
     // TODO(Matthias): Consider unifying with the byte memory example?

--- a/circuits/src/generation/halfword_memory.rs
+++ b/circuits/src/generation/halfword_memory.rs
@@ -78,7 +78,7 @@ mod tests {
     };
     use crate::generation::memory::generate_memory_trace;
     use crate::generation::memoryinit::generate_memory_init_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::test_utils::{inv, prep_table};
 
     // TODO(Matthias): Consider unifying with the byte memory example?
@@ -161,8 +161,8 @@ mod tests {
         let fullword_memory = generate_fullword_memory_trace(&record.executed);
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
-        let poseidon2_rows = generate_poseidon2_sponge_trace(&record.executed);
-        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_rows);
+        let poseidon2_sponge_rows = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_rows);
 
         let trace = generate_memory_trace::<GoldilocksField>(
             &record.executed,
@@ -171,7 +171,7 @@ mod tests {
             &fullword_memory,
             &io_memory_private_rows,
             &io_memory_public_rows,
-            &poseidon2_rows,
+            &poseidon2_sponge_rows,
             &poseidon2_output_bytes,
         );
         assert_eq!(trace,

--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -246,11 +246,11 @@ mod tests {
         generate_io_memory_private_trace, generate_io_memory_public_trace,
     };
     use crate::generation::memoryinit::generate_memory_init_trace;
-    use crate::generation::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
     use crate::memory::columns::Memory;
     use crate::memory::stark::MemoryStark;
     use crate::memory::test_utils::memory_trace_test_case;
+    use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::stark::utils::trace_rows_to_poly_values;
     use crate::test_utils::{fast_test_config, inv, prep_table};
 
@@ -341,8 +341,8 @@ mod tests {
         let fullword_memory = generate_fullword_memory_trace(&record.executed);
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
-        let poseidon2_trace = generate_poseidon2_sponge_trace(&record.executed);
-        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_trace);
+        let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_trace);
 
         let trace = super::generate_memory_trace::<GoldilocksField>(
             &record.executed,
@@ -351,7 +351,7 @@ mod tests {
             &fullword_memory,
             &io_memory_private_rows,
             &io_memory_public_rows,
-            &poseidon2_trace,
+            &poseidon2_sponge_trace,
             &poseidon2_output_bytes,
         );
         assert_eq!(

--- a/circuits/src/generation/mod.rs
+++ b/circuits/src/generation/mod.rs
@@ -11,9 +11,6 @@ pub mod io_memory;
 pub mod memory;
 pub mod memory_zeroinit;
 pub mod memoryinit;
-pub mod poseidon2;
-pub mod poseidon2_output_bytes;
-pub mod poseidon2_sponge;
 pub mod program;
 pub mod rangecheck;
 pub mod rangecheck_u8;
@@ -44,8 +41,6 @@ use self::memoryinit::{
     generate_call_tape_init_trace, generate_event_tape_init_trace, generate_memory_init_trace,
     generate_private_tape_init_trace, generate_public_tape_init_trace,
 };
-use self::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-use self::poseidon2_sponge::generate_poseidon2_sponge_trace;
 use self::rangecheck::generate_rangecheck_trace;
 use self::rangecheck_u8::generate_rangecheck_u8_trace;
 use self::xor::generate_xor_trace;
@@ -57,8 +52,10 @@ use crate::generation::memory_zeroinit::generate_memory_zero_init_trace;
 use crate::generation::memoryinit::{
     generate_elf_memory_init_trace, generate_mozak_memory_init_trace,
 };
-use crate::generation::poseidon2::generate_poseidon2_trace;
 use crate::generation::program::generate_program_rom_trace;
+use crate::poseidon2::generation::generate_poseidon2_trace;
+use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
 use crate::register::generation::{generate_register_init_trace, generate_register_trace};
 use crate::stark::mozak_stark::{
     all_starks, MozakStark, PublicInputs, TableKindArray, TableKindSetBuilder,

--- a/circuits/src/generation/rangecheck.rs
+++ b/circuits/src/generation/rangecheck.rs
@@ -97,9 +97,9 @@ mod tests {
     };
     use crate::generation::memory::generate_memory_trace;
     use crate::generation::memoryinit::generate_memory_init_trace;
-    use crate::generation::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
     use crate::generation::MIN_TRACE_LENGTH;
+    use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::register::generation::{generate_register_init_trace, generate_register_trace};
 
     #[test]
@@ -126,8 +126,8 @@ mod tests {
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
         let call_tape_rows = generate_call_tape_trace(&record.executed);
-        let poseidon2_trace = generate_poseidon2_sponge_trace(&record.executed);
-        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_trace);
+        let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_trace);
         let memory_rows = generate_memory_trace::<F>(
             &record.executed,
             &memory_init,
@@ -135,7 +135,7 @@ mod tests {
             &fullword_memory,
             &io_memory_private_rows,
             &io_memory_public_rows,
-            &poseidon2_trace,
+            &poseidon2_sponge_trace,
             &poseidon2_output_bytes,
         );
         let register_init = generate_register_init_trace(&record);

--- a/circuits/src/generation/rangecheck_u8.rs
+++ b/circuits/src/generation/rangecheck_u8.rs
@@ -75,8 +75,8 @@ mod tests {
     };
     use crate::generation::memory::generate_memory_trace;
     use crate::generation::memoryinit::generate_memory_init_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
     use crate::generation::rangecheck::generate_rangecheck_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::register::generation::{generate_register_init_trace, generate_register_trace};
 
     #[test]
@@ -103,8 +103,8 @@ mod tests {
         let io_memory_private = generate_io_memory_private_trace(&record.executed);
         let io_memory_public = generate_io_memory_public_trace(&record.executed);
         let call_tape = generate_call_tape_trace(&record.executed);
-        let poseidon2_trace = generate_poseidon2_sponge_trace(&record.executed);
-        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_trace);
+        let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_trace);
         let memory_rows = generate_memory_trace::<F>(
             &record.executed,
             &memory_init,
@@ -112,7 +112,7 @@ mod tests {
             &fullword_memory,
             &io_memory_private,
             &io_memory_public,
-            &poseidon2_trace,
+            &poseidon2_sponge_trace,
             &poseidon2_output_bytes,
         );
         let register_init = generate_register_init_trace(&record);

--- a/circuits/src/memory/stark.rs
+++ b/circuits/src/memory/stark.rs
@@ -272,10 +272,10 @@ mod tests {
         generate_elf_memory_init_trace, generate_memory_init_trace,
         generate_mozak_memory_init_trace,
     };
-    use crate::generation::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
     use crate::memory::stark::MemoryStark;
     use crate::memory::test_utils::memory_trace_test_case;
+    use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::stark::mozak_stark::{
         ElfMemoryInitTable, MozakMemoryInitTable, MozakStark, TableKindSetBuilder,
     };
@@ -375,10 +375,10 @@ mod tests {
         let fullword_memory_rows = generate_fullword_memory_trace(&record.executed);
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
-        let poseiden2_sponge_rows = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_sponge_rows = generate_poseidon2_sponge_trace(&record.executed);
         #[allow(unused)]
         let poseidon2_output_bytes_rows =
-            generate_poseidon2_output_bytes_trace(&poseiden2_sponge_rows);
+            generate_poseidon2_output_bytes_trace(&poseidon2_sponge_rows);
         let mut memory_rows = generate_memory_trace(
             &record.executed,
             &generate_memory_init_trace(&program),
@@ -386,7 +386,7 @@ mod tests {
             &fullword_memory_rows,
             &io_memory_private_rows,
             &io_memory_public_rows,
-            &poseiden2_sponge_rows,
+            &poseidon2_sponge_rows,
             &poseidon2_output_bytes_rows,
         );
         // malicious prover sets first memory row's is_init to zero

--- a/circuits/src/poseidon2/generation.rs
+++ b/circuits/src/poseidon2/generation.rs
@@ -175,16 +175,11 @@ pub fn generate_poseidon2_trace<F: RichField>(step_rows: &[Row<F>]) -> Vec<Posei
 mod test {
 
     use plonky2::field::types::Sample;
-    use plonky2::hash::poseidon2::Poseidon2;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
-    use crate::generation::poseidon2::{
-        generate_1st_full_round_state, generate_2st_full_round_state, generate_partial_round_state,
-        FullRoundOutput,
-    };
-    use crate::generation::MIN_TRACE_LENGTH;
-    use crate::poseidon2::columns::{Poseidon2State, ROUNDS_F, STATE_SIZE};
+    use super::*;
     use crate::test_utils::{create_poseidon2_test, Poseidon2Test};
+
     const D: usize = 2;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D>>::F;

--- a/circuits/src/poseidon2/mod.rs
+++ b/circuits/src/poseidon2/mod.rs
@@ -1,2 +1,3 @@
 pub mod columns;
+pub mod generation;
 pub mod stark;

--- a/circuits/src/poseidon2/stark.rs
+++ b/circuits/src/poseidon2/stark.rs
@@ -451,7 +451,7 @@ mod tests {
     use starky::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
     use starky::verifier::verify_stark_proof;
 
-    use crate::generation::poseidon2::generate_poseidon2_trace;
+    use crate::poseidon2::generation::generate_poseidon2_trace;
     use crate::poseidon2::stark::Poseidon2_12Stark;
     use crate::stark::utils::trace_rows_to_poly_values;
     use crate::test_utils::{create_poseidon2_test, Poseidon2Test};

--- a/circuits/src/poseidon2_output_bytes/generation.rs
+++ b/circuits/src/poseidon2_output_bytes/generation.rs
@@ -1,6 +1,6 @@
 use plonky2::hash::hash_types::RichField;
 
-use super::MIN_TRACE_LENGTH;
+use crate::generation::MIN_TRACE_LENGTH;
 use crate::poseidon2_output_bytes::columns::Poseidon2OutputBytes;
 use crate::poseidon2_sponge::columns::Poseidon2Sponge;
 
@@ -31,8 +31,8 @@ mod tests {
     use mozak_runner::vm::Row;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
     use crate::generation::MIN_TRACE_LENGTH;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::test_utils::{create_poseidon2_test, Poseidon2Test};
     const D: usize = 2;
     type C = PoseidonGoldilocksConfig;

--- a/circuits/src/poseidon2_output_bytes/mod.rs
+++ b/circuits/src/poseidon2_output_bytes/mod.rs
@@ -1,2 +1,3 @@
 pub mod columns;
+pub mod generation;
 pub mod stark;

--- a/circuits/src/poseidon2_output_bytes/stark.rs
+++ b/circuits/src/poseidon2_output_bytes/stark.rs
@@ -100,8 +100,8 @@ mod tests {
     use starky::verifier::verify_stark_proof;
 
     use super::Poseidon2OutputBytesStark;
-    use crate::generation::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
+    use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::stark::utils::trace_rows_to_poly_values;
     use crate::test_utils::{create_poseidon2_test, Poseidon2Test};
 

--- a/circuits/src/poseidon2_sponge/generation.rs
+++ b/circuits/src/poseidon2_sponge/generation.rs
@@ -7,9 +7,7 @@ use plonky2::hash::poseidon2::Poseidon2Permutation;
 use crate::generation::MIN_TRACE_LENGTH;
 use crate::poseidon2_sponge::columns::{Ops, Poseidon2Sponge};
 
-fn pad_poseidon2_sponge_trace<F: RichField>(
-    mut trace: Vec<Poseidon2Sponge<F>>,
-) -> Vec<Poseidon2Sponge<F>> {
+fn pad_trace<F: RichField>(mut trace: Vec<Poseidon2Sponge<F>>) -> Vec<Poseidon2Sponge<F>> {
     trace.resize(
         trace.len().next_power_of_two().max(MIN_TRACE_LENGTH),
         Poseidon2Sponge::default(),
@@ -61,7 +59,7 @@ fn unroll_sponge_data<F: RichField>(row: &Row<F>) -> Vec<Poseidon2Sponge<F>> {
 pub fn generate_poseidon2_sponge_trace<F: RichField>(
     step_rows: &[Row<F>],
 ) -> Vec<Poseidon2Sponge<F>> {
-    let trace = pad_poseidon2_sponge_trace(
+    let trace = pad_trace(
         filter(step_rows)
             .map(|s| unroll_sponge_data(s))
             .collect_vec()

--- a/circuits/src/poseidon2_sponge/mod.rs
+++ b/circuits/src/poseidon2_sponge/mod.rs
@@ -1,2 +1,3 @@
 pub mod columns;
+pub mod generation;
 pub mod stark;

--- a/circuits/src/poseidon2_sponge/stark.rs
+++ b/circuits/src/poseidon2_sponge/stark.rs
@@ -214,7 +214,7 @@ mod tests {
     use starky::verifier::verify_stark_proof;
 
     use super::Poseidon2SpongeStark;
-    use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
+    use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
     use crate::stark::utils::trace_rows_to_poly_values;
     use crate::test_utils::{create_poseidon2_test, Poseidon2Test};
 

--- a/circuits/src/test_utils.rs
+++ b/circuits/src/test_utils.rs
@@ -34,14 +34,14 @@ use crate::generation::io_memory::{
 };
 use crate::generation::memory::generate_memory_trace;
 use crate::generation::memoryinit::generate_memory_init_trace;
-use crate::generation::poseidon2_output_bytes::generate_poseidon2_output_bytes_trace;
-use crate::generation::poseidon2_sponge::generate_poseidon2_sponge_trace;
 use crate::generation::rangecheck::generate_rangecheck_trace;
 use crate::generation::xor::generate_xor_trace;
 use crate::memory::stark::MemoryStark;
 use crate::memory_fullword::stark::FullWordMemoryStark;
 use crate::memory_halfword::stark::HalfWordMemoryStark;
 use crate::memory_io::stark::InputOutputMemoryStark;
+use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
+use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
 use crate::rangecheck::stark::RangeCheckStark;
 use crate::register::general::stark::RegisterStark;
 use crate::register::generation::{generate_register_init_trace, generate_register_trace};
@@ -152,8 +152,8 @@ impl ProveAndVerify for RangeCheckStark<F, D> {
         let io_memory_private = generate_io_memory_private_trace(&record.executed);
         let io_memory_public = generate_io_memory_public_trace(&record.executed);
         let call_tape = generate_call_tape_trace(&record.executed);
-        let poseidon2_trace = generate_poseidon2_sponge_trace(&record.executed);
-        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_trace);
+        let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_trace);
         let memory_trace = generate_memory_trace::<F>(
             &record.executed,
             &memory_init,
@@ -161,7 +161,7 @@ impl ProveAndVerify for RangeCheckStark<F, D> {
             &fullword_memory,
             &io_memory_private,
             &io_memory_public,
-            &poseidon2_trace,
+            &poseidon2_sponge_trace,
             &poseidon2_output_bytes,
         );
         let register_init = generate_register_init_trace(record);
@@ -221,8 +221,8 @@ impl ProveAndVerify for MemoryStark<F, D> {
         let fullword_memory = generate_fullword_memory_trace(&record.executed);
         let io_memory_private = generate_io_memory_private_trace(&record.executed);
         let io_memory_public = generate_io_memory_public_trace(&record.executed);
-        let poseidon2_trace = generate_poseidon2_sponge_trace(&record.executed);
-        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_trace);
+        let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
+        let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_trace);
         let trace_poly_values = trace_rows_to_poly_values(generate_memory_trace(
             &record.executed,
             &memory_init,
@@ -230,7 +230,7 @@ impl ProveAndVerify for MemoryStark<F, D> {
             &fullword_memory,
             &io_memory_private,
             &io_memory_public,
-            &poseidon2_trace,
+            &poseidon2_sponge_trace,
             &poseidon2_output_bytes,
         ));
         let proof = prove_table::<F, C, S, D>(


### PR DESCRIPTION
This is 100% copy and paste poseidon2 generation code into its specific directories, as part of an effort to delete `generation` and move trace gen code into their specific kind of table.

No actual logic is changed, so please review for naming and if there's any careless mistakes in moving/renaming.