### PR TITLE
sdk: remove redundant clippy lint allowances from `ecall.rs`

### DIFF
--- a/sdk/src/core/ecall.rs
+++ b/sdk/src/core/ecall.rs
@@ -124,12 +124,6 @@ pub fn trace(msg_ptr: *const u8, msg_len: usize) {
 
 pub fn halt(output: u8) {
     #[cfg(target_os = "mozakvm")]
-    // HALT ecall
-    //
-    // As per RISC-V Calling Convention a0/a1 (which are actually X10/X11) can be
-    // used as function argument/result.
-    // a0 is used to indicate that its HALT system call.
-    // a1 is used to pass output bytes.
     unsafe {
         asm!(
             "ecall",


### PR DESCRIPTION
extracted from #1497, in [0705cb4](https://github.com/0xmozak/mozak-vm/pull/1497/commits/0705cb4f6b120ec0eb3a099058fbbc9f38b8d79b)