### PR TITLE
runner: use exhaustive match over non-exhaustive match

### DIFF
--- a/runner/src/ecall.rs
+++ b/runner/src/ecall.rs
@@ -120,7 +120,7 @@ impl<F: RichField> State<F> {
             ecall::PANIC => self.ecall_panic(),
             ecall::POSEIDON2 => self.ecall_poseidon2(),
             ecall::VM_TRACE_LOG => self.ecall_trace_log(),
-            _ => (Aux::default(), self.bump_pc()),
+            ecall::VM_TRACE_LOG..=u32::MAX => (Aux::default(), self.bump_pc()),
         }
     }
 }


### PR DESCRIPTION
While working on adding ecalls for IOReads of the tapes, noticed that this match statement did not scream at me for missing ecalls - because the `_` match arm accounts for it. Using an exhaustive version will cause a compile error and hence catch the missing ecall during compile time.