### PR TITLE
Allow specifying a name for your `COL_MAP`

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -92,7 +92,7 @@ pub struct Instruction<T> {
     pub imm_value: T,
 }
 
-make_col_map!(CPU, CpuState);
+make_col_map!(CpuState);
 columns_view_impl!(CpuState);
 /// Represents the State of the CPU, which is also a row of the trace
 #[repr(C)]
@@ -188,6 +188,7 @@ pub struct CpuState<T> {
     pub poseidon2_input_addr: T,
     pub poseidon2_input_len: T,
 }
+pub(crate) const CPU: &CpuState<ColumnWithTypedInput<CpuState<i64>>> = &COL_MAP;
 
 impl<T: PackedField> CpuState<T> {
     #[must_use]


### PR DESCRIPTION
Split off from https://github.com/0xmozak/mozak-vm/pull/1503