### PR TITLE
runner(state): Do not hide `Clone` behind `From<&Program>`

### DIFF
--- a/circuits/tests/riscv_tests.rs
+++ b/circuits/tests/riscv_tests.rs
@@ -24,7 +24,7 @@ use starky::config::StarkConfig;
 fn run_test(elf: &[u8]) -> Result<()> {
     let _ = env_logger::try_init();
     let program = Program::vanilla_load_elf(elf)?;
-    let state = State::<GoldilocksField>::from(&program);
+    let state = State::<GoldilocksField>::from(program.clone());
     let record = step(&program, state)?;
     let state = record.last_state.clone();
     // At the end of every test,

--- a/runner/benches/fibonacci.rs
+++ b/runner/benches/fibonacci.rs
@@ -14,7 +14,7 @@ fn fibonacci_benchmark(c: &mut Criterion) {
     group.bench_function("fibonacci", |b| {
         b.iter(|| {
             let program = Program::vanilla_load_elf(FIBONACCI_ELF).unwrap();
-            let state = State::<GoldilocksField>::from(&program);
+            let state = State::<GoldilocksField>::from(program.clone());
             let _state = step(&program, state).unwrap();
         })
     });

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -153,10 +153,6 @@ impl<F: RichField> From<Program> for State<F> {
     }
 }
 
-impl<F: RichField> From<&Program> for State<F> {
-    fn from(program: &Program) -> Self { Self::from(program.clone()) }
-}
-
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MemEntry {
     pub addr: u32,

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -1355,9 +1355,11 @@ mod tests {
         let image: HashMap<u32, u32> = mem.iter().chain(exit_inst.iter()).copied().collect();
         let program = Program::from(image);
 
-        let state = regs.iter().fold(State::from(&program), |state, (rs, val)| {
-            state.set_register_value(*rs, *val)
-        });
+        let state = regs
+            .iter()
+            .fold(State::from(program.clone()), |state, (rs, val)| {
+                state.set_register_value(*rs, *val)
+            });
 
         let record = step(&program, state).unwrap();
         assert!(record.last_state.has_halted());


### PR DESCRIPTION
This is bad API - clone upfront so that the caller knows the cost upfront.