### PR TITLE
runner(state): delete legacy_ecall_api_new

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
                 .map(|s| tapes_to_runtime_arguments(s, self_prog_id))
                 .unwrap_or_default();
             let program = load_program(elf, &args).unwrap();
-            let state = State::<GoldilocksField>::legacy_ecall_api_new(program.clone(), args);
+            let state = State::<GoldilocksField>::new(program.clone());
             step(&program, state)?;
         }
         Command::ProveAndVerify(RunArgs {
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
                 .unwrap_or_default();
 
             let program = load_program(elf, &args).unwrap();
-            let state = State::<GoldilocksField>::legacy_ecall_api_new(program.clone(), args);
+            let state = State::<GoldilocksField>::new(program.clone());
 
             let record = step(&program, state)?;
             prove_and_verify_mozak_stark(&program, &record, &config)?;
@@ -161,7 +161,7 @@ fn main() -> Result<()> {
                 .map(|s| tapes_to_runtime_arguments(s, self_prog_id))
                 .unwrap_or_default();
             let program = load_program(elf, &args).unwrap();
-            let state = State::<GoldilocksField>::legacy_ecall_api_new(program.clone(), args);
+            let state = State::<GoldilocksField>::new(program.clone());
             let record = step(&program, state)?;
             let stark = if cli.debug {
                 MozakStark::default_debug()
@@ -258,8 +258,7 @@ fn main() -> Result<()> {
                     }),
                     &args,
                 )?;
-                let state =
-                    State::<GoldilocksField>::legacy_ecall_api_new(program.clone(), args.clone());
+                let state = State::<GoldilocksField>::new(program.clone());
                 let record = step(&program, state)?;
 
                 let hash_from_poly_values = |poly_values: Vec<PolynomialValues<F>>| {

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -11,7 +11,7 @@ use plonky2::hash::hash_types::RichField;
 use serde::{Deserialize, Serialize};
 
 use crate::code::Code;
-use crate::elf::{Data, Program, RuntimeArguments};
+use crate::elf::{Data, Program};
 use crate::instruction::{Args, DecodingError, Instruction};
 use crate::poseidon2;
 
@@ -194,39 +194,6 @@ pub struct Aux<F: RichField> {
 }
 
 impl<F: RichField> State<F> {
-    #[must_use]
-    #[allow(clippy::similar_names)]
-    // TODO(Roman): currently this function uses old io-tape mechanism (based on
-    // `ecall`) once a new stark mechanics related to io-tapes will be added, this
-    // function will be used only for old-io-tapes API, and another function
-    // `new_mozak_elf` will be added specifically for new io-tapes mechanism
-    // NOTE: currently, both mozak-elf and vanilla elf will use this API since there
-    // is still no stark-backend that supports new-io-tapes
-    pub fn legacy_ecall_api_new(
-        Program {
-            rw_memory: Data(rw_memory),
-            ro_memory: Data(ro_memory),
-            mozak_ro_memory,
-            entry_point: pc,
-            ..
-        }: Program,
-        RuntimeArguments { .. }: RuntimeArguments,
-    ) -> Self {
-        let memory = StateMemory::new(
-            [
-                ro_memory,
-                mozak_ro_memory.map(HashMap::from).unwrap_or_default(),
-            ]
-            .into_iter(),
-            once(rw_memory),
-        );
-        Self {
-            pc,
-            memory,
-            ..Default::default()
-        }
-    }
-
     #[must_use]
     #[allow(clippy::similar_names)]
     /// # Panics


### PR DESCRIPTION
The implementation is the same as `new`.