### PR TITLE
Remove counter-productive 'debug' option

### DIFF
--- a/circuits/src/expr.rs
+++ b/circuits/src/expr.rs
@@ -185,15 +185,7 @@ pub fn build_packed<F, FE, P, const D: usize, const D2: usize>(
         .map(|c| c.map(|constraint| evaluator.eval(constraint)))
         .collect::<Vec<_>>();
 
-    let mozak_stark_debug = std::env::var("MOZAK_STARK_DEBUG").is_ok();
     for c in evaluated {
-        if mozak_stark_debug && !c.term.is_zeros() {
-            log::error!(
-                "ConstraintConsumer - DEBUG trace (non-zero-constraint): {}",
-                c.location
-            );
-        }
-
         (match c.constraint_type {
             ConstraintType::FirstRow => ConstraintConsumer::constraint_first_row,
             ConstraintType::Always => ConstraintConsumer::constraint,


### PR DESCRIPTION
Alas, sticking debug output in the PackedField evaluator ain't the right place: thanks to some cryptographic shenanigans, a non-zero result there doesn't actually mean that our constraints are failing.

We can introduce a debug-evaluator later that does what this was trying to do.