### PR TITLE
Always enable Poseidon2 starks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compile and archive all the tests
-        run: nixdo nice cargo nextest archive --cargo-profile="${{ matrix.profile }}" --locked --features="enable_poseidon_starks, test_public_table" --all-targets --archive-file mozak-vm-tests.tar.zst
+        run: nixdo nice cargo nextest archive --cargo-profile="${{ matrix.profile }}" --locked --features="test_public_table" --all-targets --archive-file mozak-vm-tests.tar.zst
 
       - name: Run all the tests from the archive
         run: nixdo MOZAK_STARK_DEBUG=true nice cargo nextest run --no-fail-fast --archive-file mozak-vm-tests.tar.zst

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -29,10 +29,10 @@ jobs:
       # TODO(Matthias): consider de-duplicating with `.github/workflows/ci.yml`
       # to make keeping these in sync easier.
       - name: Compile
-        run: cargo test --no-run --locked --features="enable_poseidon_starks" --all-targets
+        run: cargo test --no-run --locked --all-targets
 
       - name: Test
-        run: MOZAK_STARK_DEBUG=true cargo nextest run --no-fail-fast --locked --features="enable_poseidon_starks" --all-targets
+        run: MOZAK_STARK_DEBUG=true cargo nextest run --no-fail-fast --locked --all-targets
 
       - name: Create github issue for failed action
         uses: imjohnbo/issue-bot@v3

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -37,7 +37,6 @@ mozak-runner = { path = "../runner", features = ["test"] }
 proptest = "1.4"
 
 [features]
-enable_poseidon_starks = []
 parallel = ["plonky2/parallel", "starky/parallel", "plonky2_maybe_rayon/parallel"]
 test = []
 test_public_table = []

--- a/circuits/src/generation/cpu.rs
+++ b/circuits/src/generation/cpu.rs
@@ -84,13 +84,10 @@ pub fn generate_cpu_trace<F: RichField>(record: &ExecutionRecord<F>) -> Vec<CpuS
             xor: generate_xor_row(&inst, state),
             mem_addr: F::from_canonical_u32(aux.mem.unwrap_or_default().addr),
             mem_value_raw: from_u32(aux.mem.unwrap_or_default().raw_value),
-            #[cfg(feature = "enable_poseidon_starks")]
             is_poseidon2: F::from_bool(aux.poseidon2.is_some()),
-            #[cfg(feature = "enable_poseidon_starks")]
             poseidon2_input_addr: F::from_canonical_u32(
                 aux.poseidon2.clone().unwrap_or_default().addr,
             ),
-            #[cfg(feature = "enable_poseidon_starks")]
             poseidon2_input_len: F::from_canonical_u32(
                 aux.poseidon2.clone().unwrap_or_default().len,
             ),

--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -84,14 +84,12 @@ pub fn transform_halfword<F: RichField>(
         .flat_map(Into::<Vec<Memory<F>>>::into)
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 pub fn transform_poseidon2_sponge<F: RichField>(
     sponge_data: &[Poseidon2Sponge<F>],
 ) -> impl Iterator<Item = Memory<F>> + '_ {
     sponge_data.iter().flat_map(Into::<Vec<Memory<F>>>::into)
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 pub fn transform_poseidon2_output_bytes<F: RichField>(
     output_bytes: &[Poseidon2OutputBytes<F>],
 ) -> impl Iterator<Item = Memory<F>> + '_ {
@@ -142,9 +140,7 @@ pub fn generate_memory_trace<F: RichField>(
     fullword_memory_rows: &[FullWordMemory<F>],
     io_memory_private_rows: &[InputOutputMemory<F>],
     io_memory_public_rows: &[InputOutputMemory<F>],
-    #[allow(unused)] //
     poseidon2_sponge_rows: &[Poseidon2Sponge<F>],
-    #[allow(unused)] //
     poseidon2_output_bytes_rows: &[Poseidon2OutputBytes<F>],
 ) -> Vec<Memory<F>> {
     // `merged_trace` is address sorted combination of static and
@@ -157,15 +153,10 @@ pub fn generate_memory_trace<F: RichField>(
         transform_fullword(fullword_memory_rows),
         transform_io(io_memory_private_rows),
         transform_io(io_memory_public_rows),
+        transform_poseidon2_sponge(poseidon2_sponge_rows),
+        transform_poseidon2_output_bytes(poseidon2_output_bytes_rows,),
     )
     .collect();
-
-    #[cfg(feature = "enable_poseidon_starks")]
-    merged_trace.extend(transform_poseidon2_sponge(poseidon2_sponge_rows));
-    #[cfg(feature = "enable_poseidon_starks")]
-    merged_trace.extend(transform_poseidon2_output_bytes(
-        poseidon2_output_bytes_rows,
-    ));
 
     merged_trace.sort_by_key(key);
     let mut merged_trace: Vec<_> = merged_trace

--- a/circuits/src/generation/mod.rs
+++ b/circuits/src/generation/mod.rs
@@ -89,9 +89,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
     let call_tape_rows = generate_call_tape_trace(&record.executed);
     let poseiden2_sponge_rows = generate_poseidon2_sponge_trace(&record.executed);
-    #[allow(unused)]
     let poseidon2_output_bytes_rows = generate_poseidon2_output_bytes_trace(&poseiden2_sponge_rows);
-    #[allow(unused)]
     let poseidon2_rows = generate_poseidon2_trace(&record.executed);
     let memory_rows = generate_memory_trace(
         &record.executed,
@@ -145,11 +143,8 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         register_stark: trace_rows_to_poly_values(register_rows),
         register_zero_read_stark: trace_rows_to_poly_values(register_zero_read_rows),
         register_zero_write_stark: trace_rows_to_poly_values(register_zero_write_rows),
-        #[cfg(feature = "enable_poseidon_starks")]
         poseidon2_stark: trace_rows_to_poly_values(poseidon2_rows),
-        #[cfg(feature = "enable_poseidon_starks")]
         poseidon2_sponge_stark: trace_rows_to_poly_values(poseiden2_sponge_rows),
-        #[cfg(feature = "enable_poseidon_starks")]
         poseidon2_output_bytes_stark: trace_rows_to_poly_values(poseidon2_output_bytes_rows),
     }
     .build()

--- a/circuits/src/memory/stark.rs
+++ b/circuits/src/memory/stark.rs
@@ -316,7 +316,6 @@ mod tests {
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
         let poseidon2_sponge_rows = generate_poseidon2_sponge_trace(&record.executed);
-        #[allow(unused)]
         let poseidon2_output_bytes_rows =
             generate_poseidon2_output_bytes_trace(&poseidon2_sponge_rows);
         let mut memory_rows = generate_memory_trace(

--- a/circuits/src/poseidon2/columns.rs
+++ b/circuits/src/poseidon2/columns.rs
@@ -1,9 +1,7 @@
 use plonky2::hash::poseidon2::{ROUND_F_END, ROUND_P, WIDTH};
 
 use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::linear_combination::Column;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::stark::mozak_stark::{Poseidon2Table, TableWithTypedOutput};
 
 /// The size of the state
@@ -60,7 +58,6 @@ pub struct Poseidon2StateCtl<F> {
     pub output: [F; STATE_SIZE],
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_sponge() -> TableWithTypedOutput<Poseidon2StateCtl<Column>> {
     // Extend data with outputs which is basically state after last full round.

--- a/circuits/src/poseidon2_output_bytes/columns.rs
+++ b/circuits/src/poseidon2_output_bytes/columns.rs
@@ -2,14 +2,10 @@ use plonky2::hash::hash_types::{HashOut, RichField};
 use plonky2::plonk::config::GenericHashOut;
 
 use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::cross_table_lookup::ColumnWithTypedInput;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::linear_combination::Column;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::memory::columns::MemoryCtl;
 use crate::poseidon2_sponge::columns::Poseidon2Sponge;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::stark::mozak_stark::{Poseidon2OutputBytesTable, TableWithTypedOutput};
 
 pub const FIELDS_COUNT: usize = 4;
@@ -63,7 +59,6 @@ pub struct Poseidon2OutputBytesCtl<F> {
     pub output_fields: [F; FIELDS_COUNT],
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_poseidon2_sponge() -> TableWithTypedOutput<Poseidon2OutputBytesCtl<Column>> {
     Poseidon2OutputBytesTable::new(
@@ -76,7 +71,6 @@ pub fn lookup_for_poseidon2_sponge() -> TableWithTypedOutput<Poseidon2OutputByte
     )
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_output_memory(limb_index: u8) -> TableWithTypedOutput<MemoryCtl<Column>> {
     assert!(limb_index < 32, "limb_index can be 0..31");

--- a/circuits/src/poseidon2_sponge/columns.rs
+++ b/circuits/src/poseidon2_sponge/columns.rs
@@ -1,21 +1,14 @@
 use core::ops::Add;
 
-#[cfg(feature = "enable_poseidon_starks")]
 use plonky2::hash::hash_types::NUM_HASH_OUT_ELTS;
 use plonky2::hash::poseidon2::WIDTH;
 
 use crate::columns_view::{columns_view_impl, make_col_map, NumberOfColumns};
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::cross_table_lookup::ColumnWithTypedInput;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::linear_combination::Column;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::memory::columns::MemoryCtl;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::poseidon2::columns::Poseidon2StateCtl;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::poseidon2_output_bytes::columns::Poseidon2OutputBytesCtl;
-#[cfg(feature = "enable_poseidon_starks")]
 use crate::stark::mozak_stark::{Poseidon2SpongeTable, TableWithTypedOutput};
 
 #[repr(C)]
@@ -56,7 +49,6 @@ pub struct Poseidon2SpongeCtl<T> {
     pub input_len: T,
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_cpu() -> TableWithTypedOutput<Poseidon2SpongeCtl<Column>> {
     Poseidon2SpongeTable::new(
@@ -69,7 +61,6 @@ pub fn lookup_for_cpu() -> TableWithTypedOutput<Poseidon2SpongeCtl<Column>> {
     )
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_poseidon2() -> TableWithTypedOutput<Poseidon2StateCtl<Column>> {
     Poseidon2SpongeTable::new(
@@ -84,7 +75,6 @@ pub fn lookup_for_poseidon2() -> TableWithTypedOutput<Poseidon2StateCtl<Column>>
     // data
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_poseidon2_output_bytes() -> TableWithTypedOutput<Poseidon2OutputBytesCtl<Column>>
 {
@@ -98,7 +88,6 @@ pub fn lookup_for_poseidon2_output_bytes() -> TableWithTypedOutput<Poseidon2Outp
     )
 }
 
-#[cfg(feature = "enable_poseidon_starks")]
 #[must_use]
 pub fn lookup_for_input_memory(limb_index: u8) -> TableWithTypedOutput<MemoryCtl<Column>> {
     assert!(limb_index < 8, "limb_index can be 0..7");

--- a/circuits/src/stark/prover.rs
+++ b/circuits/src/stark/prover.rs
@@ -444,7 +444,6 @@ mod tests {
         MozakStark::prove_and_verify(&program, &record).unwrap();
     }
 
-    #[allow(unused)]
     fn test_poseidon2(test_data: &[Poseidon2Test]) {
         let (program, record) = create_poseidon2_test(test_data);
         for test_datum in test_data {
@@ -468,7 +467,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "enable_poseidon_starks")]
     fn prove_poseidon2() {
         test_poseidon2(&[Poseidon2Test {
             data: "💥 Mozak-VM Rocks With Poseidon2".to_string(),

--- a/circuits/src/test_utils.rs
+++ b/circuits/src/test_utils.rs
@@ -428,7 +428,6 @@ pub fn inv<F: RichField>(x: u64) -> u64 {
         .to_canonical_u64()
 }
 
-#[allow(unused)]
 pub struct Poseidon2Test {
     pub data: String,
     pub input_start_addr: u32,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.5", features = [
   "env",
   "unicode",
 ] }
-mozak-circuits = { path = "../circuits", features = ["test", "enable_poseidon_starks"] }
+mozak-circuits = { path = "../circuits", features = ["test"] }
 mozak-node = { path = "../node", features = ["std"] }
 mozak-runner = { path = "../runner", features = ["test"] }
 mozak-sdk = { path = "../sdk", features = ["std"] }


### PR DESCRIPTION
The tests are already failing when the feature is turned off, anyway, because we never run them without on the CI.

So we might as well rip out the feature toggle.