### PR TITLE
runner: rename `RuntimeArguments` to `PreinitMemory`

### DIFF
--- a/circuits/src/memory_io/stark.rs
+++ b/circuits/src/memory_io/stark.rs
@@ -157,7 +157,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for InputOutputMe
 mod tests {
     use mozak_runner::code::execute_code_with_ro_memory;
     use mozak_runner::decode::ECALL;
-    use mozak_runner::elf::{Program, RuntimeArguments};
+    use mozak_runner::elf::{PreinitMemory, Program};
     use mozak_runner::instruction::{Args, Instruction, Op};
     use mozak_runner::test_utils::{u32_extra_except_mozak_ro_memory, u8_extra};
     use mozak_runner::vm::ExecutionRecord;
@@ -178,7 +178,7 @@ mod tests {
         code: impl IntoIterator<Item = Instruction>,
         rw_mem: &[(u32, u8)],
         regs: &[(u8, u32)],
-        runtime_args: &RuntimeArguments,
+        runtime_args: &PreinitMemory,
     ) -> (Program, ExecutionRecord<GoldilocksField>) {
         execute_code_with_ro_memory(code, &[], rw_mem, regs, runtime_args)
     }
@@ -193,7 +193,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 0),       // A2 - size
             ],
-            &RuntimeArguments::default(),
+            &PreinitMemory::default(),
         );
         Stark::prove_and_verify(&program, &record).unwrap();
     }
@@ -208,7 +208,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 0),       // A2 - size
             ],
-            &RuntimeArguments::default(),
+            &PreinitMemory::default(),
         );
         Stark::prove_and_verify(&program, &record).unwrap();
     }
@@ -223,7 +223,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 0),       // A2 - size
             ],
-            &RuntimeArguments::default(),
+            &PreinitMemory::default(),
         );
         Stark::prove_and_verify(&program, &record).unwrap();
     }
@@ -238,7 +238,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            &RuntimeArguments {
+            &PreinitMemory {
                 io_tape_private,
                 ..Default::default()
             },
@@ -257,7 +257,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            &RuntimeArguments {
+            &PreinitMemory {
                 io_tape_public,
                 ..Default::default()
             },
@@ -275,7 +275,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            &RuntimeArguments {
+            &PreinitMemory {
                 call_tape,
                 ..Default::default()
             },
@@ -320,7 +320,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            &RuntimeArguments {
+            &PreinitMemory {
                 self_prog_id: vec![content],
                 cast_list: vec![content],
                 io_tape_private: vec![content],
@@ -394,7 +394,7 @@ mod tests {
                 (address.wrapping_add(3), 0),
             ],
             &[],
-            &RuntimeArguments {
+            &PreinitMemory {
                 io_tape_private: vec![content, content, content, content],
                 ..Default::default()
             },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,9 +29,9 @@ use mozak_circuits::stark::utils::trace_rows_to_poly_values;
 use mozak_circuits::stark::verifier::verify_proof;
 use mozak_circuits::test_utils::{prove_and_verify_mozak_stark, C, D, F, S};
 use mozak_cli::cli_benches::benches::BenchArgs;
-use mozak_cli::runner::{deserialize_system_tape, load_program, tapes_to_runtime_arguments};
+use mozak_cli::runner::{deserialize_system_tape, load_program, tapes_to_preinit_memory};
 use mozak_node::types::{Attestation, OpaqueAttestation, Transaction, TransparentAttestation};
-use mozak_runner::elf::RuntimeArguments;
+use mozak_runner::elf::PreinitMemory;
 use mozak_runner::state::State;
 use mozak_runner::vm::step;
 use mozak_sdk::common::types::{ProgramIdentifier, SystemTape};
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
         .init();
     match cli.command {
         Command::Decode { elf } => {
-            let program = load_program(elf, &RuntimeArguments::default())?;
+            let program = load_program(elf, &PreinitMemory::default())?;
             debug!("{program:?}");
         }
         Command::Run(RunArgs {
@@ -129,7 +129,7 @@ fn main() -> Result<()> {
             self_prog_id,
         }) => {
             let args = system_tape
-                .map(|s| tapes_to_runtime_arguments(s, self_prog_id))
+                .map(|s| tapes_to_preinit_memory(s, self_prog_id))
                 .unwrap_or_default();
             let program = load_program(elf, &args).unwrap();
             let state = State::<GoldilocksField>::new(program.clone());
@@ -141,7 +141,7 @@ fn main() -> Result<()> {
             self_prog_id,
         }) => {
             let args = system_tape
-                .map(|s| tapes_to_runtime_arguments(s, self_prog_id))
+                .map(|s| tapes_to_preinit_memory(s, self_prog_id))
                 .unwrap_or_default();
 
             let program = load_program(elf, &args).unwrap();
@@ -158,7 +158,7 @@ fn main() -> Result<()> {
             recursive_proof,
         }) => {
             let args = system_tape
-                .map(|s| tapes_to_runtime_arguments(s, self_prog_id))
+                .map(|s| tapes_to_preinit_memory(s, self_prog_id))
                 .unwrap_or_default();
             let program = load_program(elf, &args).unwrap();
             let state = State::<GoldilocksField>::new(program.clone());
@@ -247,7 +247,7 @@ fn main() -> Result<()> {
                     })
                     .unwrap_or_default();
 
-                let args = tapes_to_runtime_arguments(
+                let args = tapes_to_preinit_memory(
                     Input::try_from(&plan.system_tape_filepath).unwrap(),
                     Some(plan.self_prog_id.to_string()),
                 );
@@ -357,7 +357,7 @@ fn main() -> Result<()> {
             println!("Recursive VM proof verified successfully!");
         }
         Command::ProgramRomHash { elf } => {
-            let program = load_program(elf, &RuntimeArguments::default())?;
+            let program = load_program(elf, &PreinitMemory::default())?;
             let trace = generate_program_rom_trace(&program);
             let trace_poly_values = trace_rows_to_poly_values(trace);
             let rate_bits = config.fri_config.rate_bits;
@@ -374,7 +374,7 @@ fn main() -> Result<()> {
             println!("{trace_cap:?}");
         }
         Command::MemoryInitHash { elf } => {
-            let program = load_program(elf, &RuntimeArguments::default())?;
+            let program = load_program(elf, &PreinitMemory::default())?;
             let trace = generate_elf_memory_init_trace(&program);
             let trace_poly_values = trace_rows_to_poly_values(trace);
             let rate_bits = config.fri_config.rate_bits;

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -9,7 +9,7 @@ use plonky2::field::goldilocks_field::GoldilocksField;
 use serde::{Deserialize, Serialize};
 
 use crate::decode::{decode_instruction, ECALL};
-use crate::elf::{Program, RuntimeArguments};
+use crate::elf::{PreinitMemory, Program};
 use crate::instruction::{Args, DecodingError, Instruction, Op};
 use crate::state::State;
 use crate::vm::{step, ExecutionRecord};
@@ -62,7 +62,7 @@ pub fn execute_code_with_ro_memory(
     ro_mem: &[(u32, u8)],
     rw_mem: &[(u32, u8)],
     regs: &[(u8, u32)],
-    runtime_args: &RuntimeArguments,
+    runtime_args: &PreinitMemory,
 ) -> (Program, ExecutionRecord<GoldilocksField>) {
     let _ = env_logger::try_init();
     let ro_code = Code(
@@ -109,5 +109,5 @@ pub fn execute(
     rw_mem: &[(u32, u8)],
     regs: &[(u8, u32)],
 ) -> (Program, ExecutionRecord<GoldilocksField>) {
-    execute_code_with_ro_memory(code, &[], rw_mem, regs, &RuntimeArguments::default())
+    execute_code_with_ro_memory(code, &[], rw_mem, regs, &PreinitMemory::default())
 }

--- a/runner/src/elf.rs
+++ b/runner/src/elf.rs
@@ -193,9 +193,13 @@ impl MozakMemory {
     }
 }
 
-/// A Mozak program runtime arguments, all fields are 4 LE bytes length prefixed
+/// A representation of the preinit memory of a program compiled with the
+/// MozakVM linker script. This is injected within [`Program::create`] to be
+/// used for testing.
+///
+/// All fields are 4 LE bytes length prefixed.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct RuntimeArguments {
+pub struct PreinitMemory {
     pub self_prog_id: Vec<u8>,
     pub cast_list: Vec<u8>,
     pub io_tape_private: Vec<u8>,
@@ -204,7 +208,7 @@ pub struct RuntimeArguments {
     pub event_tape: Vec<u8>,
 }
 
-impl RuntimeArguments {
+impl PreinitMemory {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.self_prog_id.is_empty()
@@ -216,8 +220,8 @@ impl RuntimeArguments {
     }
 }
 
-impl From<&RuntimeArguments> for MozakMemory {
-    fn from(args: &RuntimeArguments) -> Self {
+impl From<&PreinitMemory> for MozakMemory {
+    fn from(args: &PreinitMemory) -> Self {
         let mut mozak_ro_memory = MozakMemory::default();
         mozak_ro_memory
             .self_prog_id
@@ -494,7 +498,7 @@ impl Program {
     /// # Panics
     /// When `Program::load_elf` or index as address is not cast-able to be u32
     /// cast-able
-    pub fn mozak_load_program(elf_bytes: &[u8], args: &RuntimeArguments) -> Result<Program> {
+    pub fn mozak_load_program(elf_bytes: &[u8], args: &PreinitMemory) -> Result<Program> {
         let mut program =
             Program::mozak_load_elf(elf_bytes, Program::parse_and_validate_elf(elf_bytes)?);
         let mozak_ro_memory = program
@@ -521,7 +525,7 @@ impl Program {
     }
 
     /// Creates a [`Program`] with preinitialized mozak memory given its memory,
-    /// [`Code`] and [`RuntimeArguments`].
+    /// [`Code`] and [`PreinitMemory`].
     ///
     /// # Panics
     ///
@@ -533,7 +537,7 @@ impl Program {
         ro_mem: &[(u32, u8)],
         rw_mem: &[(u32, u8)],
         ro_code: Code,
-        args: &RuntimeArguments,
+        args: &PreinitMemory,
     ) -> Program {
         let ro_memory = Data(ro_mem.iter().copied().collect());
         let rw_memory = Data(rw_mem.iter().copied().collect());
@@ -583,8 +587,7 @@ mod test {
 
     #[test]
     fn test_mozak_load_program_default() {
-        Program::mozak_load_program(mozak_examples::EMPTY_ELF, &RuntimeArguments::default())
-            .unwrap();
+        Program::mozak_load_program(mozak_examples::EMPTY_ELF, &PreinitMemory::default()).unwrap();
     }
 
     #[test]
@@ -592,7 +595,7 @@ mod test {
         let data = vec![0, 1, 2, 3];
 
         let mozak_ro_memory =
-            Program::mozak_load_program(mozak_examples::EMPTY_ELF, &RuntimeArguments {
+            Program::mozak_load_program(mozak_examples::EMPTY_ELF, &PreinitMemory {
                 self_prog_id: data.clone(),
                 cast_list: data.clone(),
                 io_tape_private: data.clone(),


### PR DESCRIPTION
`RuntimeArguments` was a bad name - it is too generic (what arguments exactly are we passing at runtime?) This was also causing some confusion to myself as I was working on the commitment tape work.

We rename them to `PreinitMemory`.