### PR TITLE
Add Diaresis

### DIFF
--- a/circuits/src/memory_io/stark.rs
+++ b/circuits/src/memory_io/stark.rs
@@ -157,7 +157,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for InputOutputMe
 mod tests {
     use mozak_runner::code::execute_code_with_ro_memory;
     use mozak_runner::decode::ECALL;
-    use mozak_runner::elf::{PreinitMemory, Program};
+    use mozak_runner::elf::{PreïnitMemory, Program};
     use mozak_runner::instruction::{Args, Instruction, Op};
     use mozak_runner::state::State;
     use mozak_runner::test_utils::{u32_extra_except_mozak_ro_memory, u8_extra};
@@ -179,7 +179,7 @@ mod tests {
         code: impl IntoIterator<Item = Instruction>,
         rw_mem: &[(u32, u8)],
         regs: &[(u8, u32)],
-        runtime_args: PreinitMemory,
+        runtime_args: PreïnitMemory,
     ) -> (Program, ExecutionRecord<GoldilocksField>) {
         execute_code_with_ro_memory(code, &[], rw_mem, regs, runtime_args)
     }
@@ -194,7 +194,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 0),       // A2 - size
             ],
-            PreinitMemory::default(),
+            PreïnitMemory::default(),
         );
         Stark::prove_and_verify(&program, &record).unwrap();
     }
@@ -209,7 +209,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 0),       // A2 - size
             ],
-            PreinitMemory::default(),
+            PreïnitMemory::default(),
         );
         Stark::prove_and_verify(&program, &record).unwrap();
     }
@@ -224,7 +224,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 0),       // A2 - size
             ],
-            PreinitMemory::default(),
+            PreïnitMemory::default(),
         );
         Stark::prove_and_verify(&program, &record).unwrap();
     }
@@ -239,7 +239,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            PreinitMemory {
+            PreïnitMemory {
                 io_tape_private,
                 ..Default::default()
             },
@@ -264,7 +264,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            PreinitMemory {
+            PreïnitMemory {
                 io_tape_public,
                 ..Default::default()
             },
@@ -288,7 +288,7 @@ mod tests {
                 (REG_A1, address), // A1 - address
                 (REG_A2, 1),       // A2 - size
             ],
-            PreinitMemory {
+            PreïnitMemory {
                 call_tape,
                 ..Default::default()
             },
@@ -364,7 +364,7 @@ mod tests {
                 (address.wrapping_add(3), 0),
             ],
             &[],
-            PreinitMemory {
+            PreïnitMemory {
                 io_tape_private: vec![content, content, content, content],
                 ..Default::default()
             },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,7 +30,7 @@ use mozak_circuits::test_utils::{prove_and_verify_mozak_stark, C, D, F, S};
 use mozak_cli::cli_benches::benches::BenchArgs;
 use mozak_cli::runner::{deserialize_system_tape, load_program, tapes_to_preinit_memory};
 use mozak_node::types::{Attestation, OpaqueAttestation, Transaction, TransparentAttestation};
-use mozak_runner::elf::PreinitMemory;
+use mozak_runner::elf::PreïnitMemory;
 use mozak_runner::state::{RawTapes, State};
 use mozak_runner::vm::step;
 use mozak_sdk::common::types::{ProgramIdentifier, SystemTape};
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
         .init();
     match cli.command {
         Command::Decode { elf } => {
-            let program = load_program(elf, &PreinitMemory::default())?;
+            let program = load_program(elf, &PreïnitMemory::default())?;
             debug!("{program:?}");
         }
         Command::Run(RunArgs {
@@ -350,7 +350,7 @@ fn main() -> Result<()> {
             println!("Recursive VM proof verified successfully!");
         }
         Command::ProgramRomHash { elf } => {
-            let program = load_program(elf, &PreinitMemory::default())?;
+            let program = load_program(elf, &PreïnitMemory::default())?;
             let trace = generate_program_rom_trace(&program);
             let trace_poly_values = trace_rows_to_poly_values(trace);
             let rate_bits = config.fri_config.rate_bits;
@@ -367,7 +367,7 @@ fn main() -> Result<()> {
             println!("{trace_cap:?}");
         }
         Command::MemoryInitHash { elf } => {
-            let program = load_program(elf, &PreinitMemory::default())?;
+            let program = load_program(elf, &PreïnitMemory::default())?;
             let trace = generate_elf_memory_init_trace(&program);
             let trace_poly_values = trace_rows_to_poly_values(trace);
             let rate_bits = config.fri_config.rate_bits;

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use clio::Input;
 use itertools::Itertools;
 use log::debug;
-use mozak_runner::elf::{PreinitMemory, Program};
+use mozak_runner::elf::{PreïnitMemory, Program};
 use mozak_sdk::common::types::{CanonicalOrderedTemporalHints, ProgramIdentifier, SystemTape};
 use rkyv::rancor::{Panic, Strategy};
 use rkyv::ser::AllocSerializer;
 
-pub fn load_program(mut elf: Input, args: &PreinitMemory) -> Result<Program> {
+pub fn load_program(mut elf: Input, args: &PreïnitMemory) -> Result<Program> {
     let mut elf_bytes = Vec::new();
     let bytes_read = elf.read_to_end(&mut elf_bytes)?;
     debug!("Read {bytes_read} of ELF data.");
@@ -58,7 +58,7 @@ fn length_prefixed_bytes(data: Vec<u8>, dgb_string: &str) -> Vec<u8> {
 /// Panics if conversion from rkyv-serialized system tape to
 /// [`PreinitMemory`](mozak_runner::elf::PreinitMemory)
 /// fails.
-pub fn tapes_to_preinit_memory(tape_bin: Input, self_prog_id: Option<String>) -> PreinitMemory {
+pub fn tapes_to_preinit_memory(tape_bin: Input, self_prog_id: Option<String>) -> PreïnitMemory {
     let sys_tapes: SystemTape = deserialize_system_tape(tape_bin).unwrap();
     let self_prog_id: ProgramIdentifier = self_prog_id.unwrap_or_default().into();
 
@@ -90,7 +90,7 @@ pub fn tapes_to_preinit_memory(tape_bin: Input, self_prog_id: Option<String>) ->
             length_prefixed_bytes(tape_bytes, dgb_string)
         }
 
-        PreinitMemory {
+        PreïnitMemory {
             self_prog_id: self_prog_id.inner().to_vec(),
             cast_list: serialise(&cast_list, "CAST_LIST"),
             io_tape_public: length_prefixed_bytes(

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -9,7 +9,7 @@ use plonky2::field::goldilocks_field::GoldilocksField;
 use serde::{Deserialize, Serialize};
 
 use crate::decode::{decode_instruction, ECALL};
-use crate::elf::{PreinitMemory, Program};
+use crate::elf::{PreïnitMemory, Program};
 use crate::instruction::{Args, DecodingError, Instruction, Op};
 use crate::state::{RawTapes, State};
 use crate::vm::{step, ExecutionRecord};
@@ -62,7 +62,7 @@ pub fn execute_code_with_ro_memory(
     ro_mem: &[(u32, u8)],
     rw_mem: &[(u32, u8)],
     regs: &[(u8, u32)],
-    preinit_mem: PreinitMemory,
+    preinit_mem: PreïnitMemory,
 ) -> (Program, ExecutionRecord<GoldilocksField>) {
     let _ = env_logger::try_init();
     let ro_code = Code(
@@ -109,5 +109,5 @@ pub fn execute(
     rw_mem: &[(u32, u8)],
     regs: &[(u8, u32)],
 ) -> (Program, ExecutionRecord<GoldilocksField>) {
-    execute_code_with_ro_memory(code, &[], rw_mem, regs, PreinitMemory::default())
+    execute_code_with_ro_memory(code, &[], rw_mem, regs, PreïnitMemory::default())
 }

--- a/runner/src/elf.rs
+++ b/runner/src/elf.rs
@@ -200,7 +200,7 @@ impl MozakMemory {
 ///
 /// TODO(bing): Remove when we move back to pure ecalls.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct PreinitMemory {
+pub struct PreïnitMemory {
     pub self_prog_id: Vec<u8>,
     pub cast_list: Vec<u8>,
     pub io_tape_private: Vec<u8>,
@@ -209,7 +209,7 @@ pub struct PreinitMemory {
     pub event_tape: Vec<u8>,
 }
 
-impl PreinitMemory {
+impl PreïnitMemory {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.self_prog_id.is_empty()
@@ -221,8 +221,8 @@ impl PreinitMemory {
     }
 }
 
-impl From<&PreinitMemory> for MozakMemory {
-    fn from(args: &PreinitMemory) -> Self {
+impl From<&PreïnitMemory> for MozakMemory {
+    fn from(args: &PreïnitMemory) -> Self {
         let mut mozak_ro_memory = MozakMemory::default();
         mozak_ro_memory
             .self_prog_id
@@ -499,7 +499,7 @@ impl Program {
     /// # Panics
     /// When `Program::load_elf` or index as address is not cast-able to be u32
     /// cast-able
-    pub fn mozak_load_program(elf_bytes: &[u8], args: &PreinitMemory) -> Result<Program> {
+    pub fn mozak_load_program(elf_bytes: &[u8], args: &PreïnitMemory) -> Result<Program> {
         let mut program =
             Program::mozak_load_elf(elf_bytes, Program::parse_and_validate_elf(elf_bytes)?);
         let mozak_ro_memory = program
@@ -538,7 +538,7 @@ impl Program {
         ro_mem: &[(u32, u8)],
         rw_mem: &[(u32, u8)],
         ro_code: Code,
-        preinit_mem: &PreinitMemory,
+        preinit_mem: &PreïnitMemory,
     ) -> Program {
         let ro_memory = Data(ro_mem.iter().copied().collect());
         let rw_memory = Data(rw_mem.iter().copied().collect());
@@ -589,7 +589,7 @@ mod test {
 
     #[test]
     fn test_mozak_load_program_default() {
-        Program::mozak_load_program(mozak_examples::EMPTY_ELF, &PreinitMemory::default()).unwrap();
+        Program::mozak_load_program(mozak_examples::EMPTY_ELF, &PreïnitMemory::default()).unwrap();
     }
 
     #[test]
@@ -597,7 +597,7 @@ mod test {
         let data = vec![0, 1, 2, 3];
 
         let mozak_ro_memory =
-            Program::mozak_load_program(mozak_examples::EMPTY_ELF, &PreinitMemory {
+            Program::mozak_load_program(mozak_examples::EMPTY_ELF, &PreïnitMemory {
                 self_prog_id: data.clone(),
                 cast_list: data.clone(),
                 io_tape_private: data.clone(),

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -11,7 +11,7 @@ use plonky2::hash::hash_types::RichField;
 use serde::{Deserialize, Serialize};
 
 use crate::code::Code;
-use crate::elf::{Data, PreinitMemory, Program};
+use crate::elf::{Data, PreïnitMemory, Program};
 use crate::instruction::{Args, DecodingError, Instruction};
 use crate::poseidon2;
 
@@ -224,8 +224,8 @@ pub struct RawTapes {
 /// compatible `RawTapes`.
 ///
 /// TODO(bing): Remove when we no longer rely on preinit memory.
-impl From<PreinitMemory> for RawTapes {
-    fn from(args: PreinitMemory) -> Self {
+impl From<PreïnitMemory> for RawTapes {
+    fn from(args: PreïnitMemory) -> Self {
         Self {
             private_tape: args.io_tape_private,
             public_tape: args.io_tape_public,


### PR DESCRIPTION
> The diaeresis[a] (/daɪˈɛrəsɪs, -ˈɪər-/ dy-ERR-ə-siss, -⁠EER-)[1] is a diacritical mark used to indicate the separation of two distinct vowel letters in adjacent syllables when an instance of diaeresis (or hiatus) occurs, so as to distinguish from a digraph or diphthong.

See https://en.wikipedia.org/wiki/Diaeresis_(diacritic)