### PR TITLE
RecursiveVerifier: Use default cap height everywhere

### DIFF
--- a/circuits/src/stark/recursive_verifier.rs
+++ b/circuits/src/stark/recursive_verifier.rs
@@ -663,8 +663,7 @@ mod tests {
         use crate::stark::verifier::verify_proof;
 
         let stark = S::default();
-        let mut config = StarkConfig::standard_fast_config();
-        config.fri_config.cap_height = 1;
+        let config = StarkConfig::standard_fast_config();
         let (program, record) = code::execute(
             [Instruction {
                 op: Op::ADD,


### PR DESCRIPTION
Tiny PR that just removes `config.fri_config.cap_height = 1;` used in `recursive_verify_mozak_starks`
Apart from not being used anywhere else ( We use default cap height 4 instead), I observed that making the change in fact  reduced the time taken by test for me.
Before the change
```
running 1 test
test stark::recursive_verifier::tests::recursive_verify_mozak_starks has been running for over 60 seconds
test stark::recursive_verifier::tests::recursive_verify_mozak_starks ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 126 filtered out; finished in 69.81s
```
After the change
```
running 1 test
test stark::recursive_verifier::tests::recursive_verify_mozak_starks has been running for over 60 seconds
test stark::recursive_verifier::tests::recursive_verify_mozak_starks ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 126 filtered out; finished in 65.86s
```
The change would also simplify https://github.com/0xmozak/mozak-vm/pull/1568, where we would have fixed size public inputs for recursive proofs.