### PR TITLE
fmt: fix formatting for code blocks with rustfmt::skip

### DIFF
--- a/circuits/src/generation/fullword_memory.rs
+++ b/circuits/src/generation/fullword_memory.rs
@@ -67,7 +67,6 @@ pub fn generate_fullword_memory_trace<F: RichField>(
 }
 #[cfg(test)]
 mod tests {
-
     use mozak_runner::code;
     use mozak_runner::elf::Program;
     use mozak_runner::instruction::Op::{LW, SW};
@@ -175,7 +174,7 @@ mod tests {
         let fullword_memory = generate_fullword_memory_trace(&record.executed);
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows= generate_io_memory_public_trace(&record.executed);
-         let call_tape_rows = generate_call_tape_trace(&record.executed);
+        let call_tape_rows = generate_call_tape_trace(&record.executed);
         let events_commitment_tape_rows = generate_events_commitment_tape_trace(&record.executed);
         let cast_list_commitment_tape_rows =
             generate_cast_list_commitment_tape_trace(&record.executed);

--- a/circuits/src/generation/halfword_memory.rs
+++ b/circuits/src/generation/halfword_memory.rs
@@ -165,7 +165,7 @@ mod tests {
         let fullword_memory = generate_fullword_memory_trace(&record.executed);
         let io_memory_private_rows = generate_io_memory_private_trace(&record.executed);
         let io_memory_public_rows = generate_io_memory_public_trace(&record.executed);
-         let call_tape_rows = generate_call_tape_trace(&record.executed);
+        let call_tape_rows = generate_call_tape_trace(&record.executed);
         let events_commitment_tape_rows = generate_events_commitment_tape_trace(&record.executed);
         let cast_list_commitment_tape_rows =
             generate_cast_list_commitment_tape_trace(&record.executed);

--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -284,9 +284,8 @@ mod tests {
 
         let call_tape_rows = generate_call_tape_trace(&record.executed);
         let events_commitment_tape_rows = generate_events_commitment_tape_trace(&record.executed);
-        let cast_list_commitment_tape_rows =
-            generate_cast_list_commitment_tape_trace(&record.executed);
-                let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
+        let cast_list_commitment_tape_rows = generate_cast_list_commitment_tape_trace(&record.executed);
+        let poseidon2_sponge_trace = generate_poseidon2_sponge_trace(&record.executed);
         let poseidon2_output_bytes = generate_poseidon2_output_bytes_trace(&poseidon2_sponge_trace);
 
         let trace = super::generate_memory_trace::<GoldilocksField>(


### PR DESCRIPTION
Builds on #1571 