### PR TITLE
Use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -1145,8 +1145,8 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "plonky2"
-version = "0.2.1"
-source = "git+https://github.com/0xmozak/plonky2.git#51f540a0e2a9bd9d6fc6234c6e62d167eaa7c707"
+version = "0.2.2"
+source = "git+https://github.com/0xmozak/plonky2.git#76e42a132e0938954ff7bc27649474ed875a5c1a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1170,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "plonky2_crypto"
 version = "0.1.0"
-source = "git+https://github.com/0xmozak/plonky2-crypto.git#49b2ea39eff2776e9c1c903ce4ca36c19a55d998"
+source = "git+https://github.com/0xmozak/plonky2-crypto.git#5e2315718c61daada8974cf11f6238c6c25d7bcd"
 dependencies = [
  "anyhow",
  "hex",
@@ -1186,8 +1186,8 @@ dependencies = [
 
 [[package]]
 name = "plonky2_field"
-version = "0.2.1"
-source = "git+https://github.com/0xmozak/plonky2.git#51f540a0e2a9bd9d6fc6234c6e62d167eaa7c707"
+version = "0.2.2"
+source = "git+https://github.com/0xmozak/plonky2.git#76e42a132e0938954ff7bc27649474ed875a5c1a"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.2.0"
-source = "git+https://github.com/0xmozak/plonky2.git#51f540a0e2a9bd9d6fc6234c6e62d167eaa7c707"
+source = "git+https://github.com/0xmozak/plonky2.git#76e42a132e0938954ff7bc27649474ed875a5c1a"
 dependencies = [
  "rayon",
 ]
@@ -1210,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.2.0"
-source = "git+https://github.com/0xmozak/plonky2.git#51f540a0e2a9bd9d6fc6234c6e62d167eaa7c707"
+source = "git+https://github.com/0xmozak/plonky2.git#76e42a132e0938954ff7bc27649474ed875a5c1a"
 
 [[package]]
 name = "plotters"
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "e3cc72858054fcff6d7dea32df2aeaee6a7c24227366d7ea429aada2f26b16ad"
 dependencies = [
  "bitflags",
  "errno",
@@ -1665,8 +1665,8 @@ dependencies = [
 
 [[package]]
 name = "starky"
-version = "0.3.0"
-source = "git+https://github.com/0xmozak/plonky2.git#51f540a0e2a9bd9d6fc6234c6e62d167eaa7c707"
+version = "0.4.0"
+source = "git+https://github.com/0xmozak/plonky2.git#76e42a132e0938954ff7bc27649474ed875a5c1a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1706,9 +1706,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1768,18 +1768,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1874,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,13 @@ lto = "fat"
 lto = "thin"
 opt-level = 3
 
+[workspace.dependencies]
+plonky2 = { git = "https://github.com/0xmozak/plonky2.git", default-features = false }
+plonky2_maybe_rayon = { git = "https://github.com/0xmozak/plonky2.git", default-features = false }
+starky = { git = "https://github.com/0xmozak/plonky2.git", default-features = false }
+
+plonky2_crypto = { git = "https://github.com/0xmozak/plonky2-crypto.git" }
+
 [patch.crates-io]
 plonky2 = { git = "https://github.com/0xmozak/plonky2.git" }
 plonky2_maybe_rayon = { git = "https://github.com/0xmozak/plonky2.git" }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -20,11 +20,11 @@ log = "0.4"
 mozak-circuits-derive = { path = "./derive" }
 mozak-runner = { path = "../runner" }
 mozak-sdk = { path = "../sdk" }
-plonky2 = { version = "0", default-features = false }
-plonky2_maybe_rayon = { version = "0", default-features = false }
+plonky2 = { workspace = true, default-features = false }
+plonky2_maybe_rayon = { workspace = true, default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-starky = { version = "0", default-features = false, features = ["std"] }
+starky = { workspace = true, default-features = false, features = ["std"] }
 thiserror = "1.0"
 tt-call = "1.0"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,11 +30,11 @@ env_logger = "0.11"
 itertools = "0.12"
 log = "0.4"
 mozak-examples = { path = "../examples-builder", features = ["mozak-sort"] }
-plonky2 = { version = "0", default-features = false }
+plonky2 = { workspace = true, default-features = false }
 rkyv = { version = "=0.8.0-alpha.1", default-features = false, features = ["pointer_width_32", "alloc"] }
 rkyv_derive = "=0.8.0-alpha.1"
 serde_json = "1.0"
-starky = { version = "0", default-features = false }
+starky = { workspace = true, default-features = false }
 tempfile = "3"
 
 [dev-dependencies]

--- a/expr/Cargo.toml
+++ b/expr/Cargo.toml
@@ -11,4 +11,4 @@ version = "0.1.0"
 
 [dependencies]
 bumpalo = "3.14"
-starky = { version = "0", default-features = false, features = ["std"] }
+starky = { workspace = true, default-features = false, features = ["std"] }

--- a/recproofs/Cargo.toml
+++ b/recproofs/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = { version = "1.0", default-features = false }
 enumflags2 = "0.7"
 iter_fixed = "0.3"
 itertools = "0.12"
-plonky2 = { version = "0", default-features = false }
-plonky2_maybe_rayon = { version = "0", default-features = false, features = ["parallel"] }
+plonky2 = { workspace = true, default-features = false }
+plonky2_maybe_rayon = { workspace = true, default-features = false, features = ["parallel"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -19,7 +19,7 @@ im = "15.1"
 itertools = "0.12"
 log = "0.4"
 mozak-sdk = { path = "../sdk" }
-plonky2 = { version = "0", default-features = false }
+plonky2 = { workspace = true, default-features = false }
 proptest = { version = "1.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -18,5 +18,5 @@ crate-type = ["cdylib", "rlib"]
 console_error_panic_hook = "0.1"
 mozak-circuits = { path = "../circuits", features = ["test"] }
 mozak-runner = { path = "../runner" }
-starky = { version = "0", features = ["std"] }
+starky = { workspace = true, features = ["std"] }
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Centralise where we specify versions for plonky2 related crates.