### PR TITLE
Update Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-03-10"
+channel = "nightly-2024-04-24"
 components = ["rustfmt", "rust-src", "clippy"]
 profile = "minimal"

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(trait_alias)]
 #![feature(raw_ref_op)]
 #![feature(stmt_expr_attributes)]
-#![feature(slice_ptr_len)]
 #![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", feature(restricted_std))]


### PR DESCRIPTION
Might as well get it out of the way.  No surprises so far.

I'm having some rust-analyzer trouble with the version that's currently in `main`.