### PR TITLE
circuits: Remove all preinit STARKs.

### DIFF
--- a/circuits/src/generation/memoryinit.rs
+++ b/circuits/src/generation/memoryinit.rs
@@ -10,11 +10,6 @@ use crate::utils::pad_trace_with_default;
 pub fn generate_memory_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
     let mut memory_inits: Vec<MemoryInit<F>> = chain! {
         elf_memory_init(program),
-        mozak_memory_init(program),
-        call_tape_init(program),
-        private_tape_init(program),
-        public_tape_init(program),
-        event_tape_init(program),
     }
     .collect();
 
@@ -35,101 +30,6 @@ where
     memory_inits.sort_by_key(|init| init.element.address.to_canonical_u64());
 
     pad_trace_with_default(memory_inits)
-}
-
-/// Generates a mozak memory init ROM trace
-#[must_use]
-pub fn generate_mozak_memory_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    let trace = generate_init_trace(program, mozak_memory_init);
-    log::trace!("MozakMemoryInit trace {:?}", trace);
-    trace
-}
-
-#[must_use]
-pub fn mozak_memory_init<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    program
-        .mozak_ro_memory
-        .iter()
-        .flat_map(|mozak_ro_memory| {
-            chain! {
-                mozak_ro_memory.self_prog_id.data.clone(),
-                mozak_ro_memory.cast_list.data.clone(),
-            }
-        })
-        .map(MemoryInit::new_readonly)
-        .collect_vec()
-}
-
-#[must_use]
-pub fn call_tape_init<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    program
-        .mozak_ro_memory
-        .iter()
-        .flat_map(|mozak_ro_memory| mozak_ro_memory.call_tape.data.clone())
-        .map(MemoryInit::new_readonly)
-        .collect_vec()
-}
-
-/// Generates a call tape memory init ROM trace
-#[must_use]
-pub fn generate_call_tape_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    let trace = generate_init_trace(program, call_tape_init);
-    log::trace!("CallTapeInit trace {:?}", trace);
-    trace
-}
-
-#[must_use]
-pub fn private_tape_init<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    program
-        .mozak_ro_memory
-        .iter()
-        .flat_map(|mozak_ro_memory| mozak_ro_memory.io_tape_private.data.clone())
-        .map(MemoryInit::new_readonly)
-        .collect_vec()
-}
-
-/// Generates a private tape memory init ROM trace
-#[must_use]
-pub fn generate_private_tape_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    let trace = generate_init_trace(program, private_tape_init);
-    log::trace!("PrivateTapeInit trace {:?}", trace);
-    trace
-}
-
-#[must_use]
-pub fn public_tape_init<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    program
-        .mozak_ro_memory
-        .iter()
-        .flat_map(|mozak_ro_memory| mozak_ro_memory.io_tape_public.data.clone())
-        .map(MemoryInit::new_readonly)
-        .collect_vec()
-}
-
-/// Generates a public tape memory init ROM trace
-#[must_use]
-pub fn generate_public_tape_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    let trace = generate_init_trace(program, public_tape_init);
-    log::trace!("PublicTapeInit trace {:?}", trace);
-    trace
-}
-
-#[must_use]
-pub fn event_tape_init<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    program
-        .mozak_ro_memory
-        .iter()
-        .flat_map(|mozak_ro_memory| mozak_ro_memory.event_tape.data.clone())
-        .map(MemoryInit::new_readonly)
-        .collect_vec()
-}
-
-/// Generates a event tape memory init ROM trace
-#[must_use]
-pub fn generate_event_tape_init_trace<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
-    let trace = generate_init_trace(program, event_tape_init);
-    log::trace!("EventTapeInit trace {:?}", trace);
-    trace
 }
 
 #[must_use]

--- a/circuits/src/generation/mod.rs
+++ b/circuits/src/generation/mod.rs
@@ -36,19 +36,14 @@ use self::io_memory::{
     generate_events_commitment_tape_trace,
 };
 use self::memory::generate_memory_trace;
-use self::memoryinit::{
-    generate_call_tape_init_trace, generate_event_tape_init_trace, generate_memory_init_trace,
-    generate_private_tape_init_trace, generate_public_tape_init_trace,
-};
+use self::memoryinit::generate_memory_init_trace;
 use self::xor::generate_xor_trace;
 use crate::columns_view::HasNamedColumns;
 use crate::generation::io_memory::{
     generate_io_memory_private_trace, generate_io_memory_public_trace,
 };
 use crate::generation::memory_zeroinit::generate_memory_zero_init_trace;
-use crate::generation::memoryinit::{
-    generate_elf_memory_init_trace, generate_mozak_memory_init_trace,
-};
+use crate::generation::memoryinit::generate_elf_memory_init_trace;
 use crate::poseidon2::generation::generate_poseidon2_trace;
 use crate::poseidon2_output_bytes::generation::generate_poseidon2_output_bytes_trace;
 use crate::poseidon2_sponge::generation::generate_poseidon2_sponge_trace;
@@ -84,11 +79,6 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
 
     let memory_init = generate_memory_init_trace(program);
     let elf_memory_init_rows = generate_elf_memory_init_trace(program);
-    let mozak_memory_init_rows = generate_mozak_memory_init_trace(program);
-    let call_tape_init_rows = generate_call_tape_init_trace(program);
-    let private_tape_init_rows = generate_private_tape_init_trace(program);
-    let public_tape_init_rows = generate_public_tape_init_trace(program);
-    let event_tape_init_rows = generate_event_tape_init_trace(program);
 
     let memory_zeroinit_rows = generate_memory_zero_init_trace(&record.executed, program);
 
@@ -145,11 +135,6 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         program_mult_stark: trace_rows_to_poly_values(program_mult_rows),
         memory_stark: trace_rows_to_poly_values(memory_rows),
         elf_memory_init_stark: trace_rows_to_poly_values(elf_memory_init_rows),
-        mozak_memory_init_stark: trace_rows_to_poly_values(mozak_memory_init_rows),
-        call_tape_init_stark: trace_rows_to_poly_values(call_tape_init_rows),
-        private_tape_init_stark: trace_rows_to_poly_values(private_tape_init_rows),
-        public_tape_init_stark: trace_rows_to_poly_values(public_tape_init_rows),
-        event_tape_init_stark: trace_rows_to_poly_values(event_tape_init_rows),
         memory_zeroinit_stark: trace_rows_to_poly_values(memory_zeroinit_rows),
         rangecheck_u8_stark: trace_rows_to_poly_values(rangecheck_u8_rows),
         halfword_memory_stark: trace_rows_to_poly_values(halfword_memory_rows),

--- a/circuits/src/memory_io/stark.rs
+++ b/circuits/src/memory_io/stark.rs
@@ -120,7 +120,7 @@ mod tests {
     use mozak_runner::elf::{Program, RuntimeArguments};
     use mozak_runner::instruction::{Args, Instruction, Op};
     use mozak_runner::state::State;
-    use mozak_runner::test_utils::{u32_extra_except_mozak_ro_memory, u8_extra};
+    use mozak_runner::test_utils::{u32_extra, u8_extra};
     use mozak_runner::vm::ExecutionRecord;
     use mozak_sdk::core::ecall::{self, COMMITMENT_SIZE};
     use mozak_sdk::core::reg_abi::{REG_A0, REG_A1, REG_A2};
@@ -395,42 +395,42 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(1))]
         #[test]
-        fn prove_io_read_private_zero_size_mozak(address in u32_extra_except_mozak_ro_memory()) {
+        fn prove_io_read_private_zero_size_mozak(address in u32_extra()) {
             prove_io_read_private_zero_size::<MozakStark<F, D>>(address);
         }
         #[test]
-        fn prove_io_read_private_mozak(address in u32_extra_except_mozak_ro_memory(), content in u8_extra()) {
+        fn prove_io_read_private_mozak(address in u32_extra(), content in u8_extra()) {
             prove_io_read_private::<MozakStark<F, D>>(address, vec![content]);
         }
         #[test]
-        fn prove_io_read_public_zero_size_mozak(address in u32_extra_except_mozak_ro_memory()) {
+        fn prove_io_read_public_zero_size_mozak(address in u32_extra()) {
             prove_io_read_public_zero_size::<MozakStark<F, D>>(address);
         }
         #[test]
-        fn prove_io_read_public_mozak(address in u32_extra_except_mozak_ro_memory(), content in u8_extra()) {
+        fn prove_io_read_public_mozak(address in u32_extra(), content in u8_extra()) {
             prove_io_read_public::<MozakStark<F, D>>(address, vec![content]);
         }
         #[test]
-        fn prove_io_read_call_tape_zero_size_mozak(address in u32_extra_except_mozak_ro_memory()) {
+        fn prove_io_read_call_tape_zero_size_mozak(address in u32_extra()) {
             prove_io_read_call_tape_zero_size::<MozakStark<F, D>>(address);
         }
         #[test]
-        fn prove_io_read_call_tape_mozak(address in u32_extra_except_mozak_ro_memory(), content in u8_extra()) {
+        fn prove_io_read_call_tape_mozak(address in u32_extra(), content in u8_extra()) {
             prove_io_read_call_tape::<MozakStark<F, D>>(address, vec![content]);
         }
 
         #[test]
-        fn prove_events_commitment_tape_mozak(address in u32_extra_except_mozak_ro_memory(), content in u8_extra()) {
+        fn prove_events_commitment_tape_mozak(address in u32_extra(), content in u8_extra()) {
             prove_events_commitment_tape::<MozakStark<F, D>>(address, [content; 32]);
         }
 
         #[test]
-        fn prove_cast_list_commitment_tape_mozak(address in u32_extra_except_mozak_ro_memory(), content in u8_extra()) {
+        fn prove_cast_list_commitment_tape_mozak(address in u32_extra(), content in u8_extra()) {
             prove_cast_list_commitment_tape::<MozakStark<F, D>>(address, [content; 32]);
         }
 
         #[test]
-        fn prove_io_read_mozak_explicit(address in u32_extra_except_mozak_ro_memory(), content in u8_extra()) {
+        fn prove_io_read_mozak_explicit(address in u32_extra(), content in u8_extra()) {
             prove_io_read_explicit::<MozakStark<F, D>>(address, content);
         }
     }

--- a/circuits/src/stark/mozak_stark.rs
+++ b/circuits/src/stark/mozak_stark.rs
@@ -90,16 +90,6 @@ pub struct MozakStark<F: RichField + Extendable<D>, const D: usize> {
     pub memory_stark: MemoryStark<F, D>,
     #[StarkSet(stark_kind = "ElfMemoryInit")]
     pub elf_memory_init_stark: MemoryInitStark<F, D>,
-    #[StarkSet(stark_kind = "CallTapeInit")]
-    pub call_tape_init_stark: MemoryInitStark<F, D>,
-    #[StarkSet(stark_kind = "PrivateTapeInit")]
-    pub private_tape_init_stark: MemoryInitStark<F, D>,
-    #[StarkSet(stark_kind = "PublicTapeInit")]
-    pub public_tape_init_stark: MemoryInitStark<F, D>,
-    #[StarkSet(stark_kind = "EventTapeInit")]
-    pub event_tape_init_stark: MemoryInitStark<F, D>,
-    #[StarkSet(stark_kind = "MozakMemoryInit")]
-    pub mozak_memory_init_stark: MemoryInitStark<F, D>,
     // TODO(Bing): find a way to natively constrain zero initializations within
     // the `MemoryStark`, instead of relying on a CTL between this and the
     // `MemoryStark`.
@@ -407,11 +397,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Default for MozakStark<F, D> 
             program_mult_stark: ProgramMultStark::default(),
             memory_stark: MemoryStark::default(),
             elf_memory_init_stark: MemoryInitStark::default(),
-            call_tape_init_stark: MemoryInitStark::default(),
-            private_tape_init_stark: MemoryInitStark::default(),
-            public_tape_init_stark: MemoryInitStark::default(),
-            event_tape_init_stark: MemoryInitStark::default(),
-            mozak_memory_init_stark: MemoryInitStark::default(),
             memory_zeroinit_stark: MemoryZeroInitStark::default(),
             rangecheck_u8_stark: RangeCheckU8Stark::default(),
             halfword_memory_stark: HalfWordMemoryStark::default(),
@@ -577,11 +562,6 @@ table_impl!(ProgramTable, TableKind::Program, ProgramRom);
 table_impl!(ProgramMultTable, TableKind::ProgramMult, ProgramMult);
 table_impl!(MemoryTable, TableKind::Memory, Memory);
 table_impl!(ElfMemoryInitTable, TableKind::ElfMemoryInit, MemoryInit);
-table_impl!(CallTapeInitTable, TableKind::CallTapeInit, MemoryInit);
-table_impl!(PrivateTapeInitTable, TableKind::PrivateTapeInit, MemoryInit);
-table_impl!(PublicTapeInitTable, TableKind::PublicTapeInit, MemoryInit);
-table_impl!(EventTapeInitTable, TableKind::EventTapeInit, MemoryInit);
-table_impl!(MozakMemoryInitTable, TableKind::MozakMemoryInit, MemoryInit);
 table_impl!(
     MemoryZeroInitTable,
     TableKind::MemoryZeroInit,
@@ -724,11 +704,6 @@ impl Lookups for MemoryInitMemoryTable {
         CrossTableLookupWithTypedOutput::new(
             vec![
                 memoryinit::columns::lookup_for_memory(ElfMemoryInitTable::new),
-                memoryinit::columns::lookup_for_memory(MozakMemoryInitTable::new),
-                memoryinit::columns::lookup_for_memory(CallTapeInitTable::new),
-                memoryinit::columns::lookup_for_memory(PrivateTapeInitTable::new),
-                memoryinit::columns::lookup_for_memory(PublicTapeInitTable::new),
-                memoryinit::columns::lookup_for_memory(EventTapeInitTable::new),
                 memory_zeroinit::columns::lookup_for_memory(),
             ],
             vec![memory::columns::lookup_for_memoryinit()],


### PR DESCRIPTION
We're in the process of removing all usages of preinit memory in favour of returning back to purely ECALLs - this includes removing (the now redundant) preinit tables for our tapes.