### PR TITLE
Remove struct `MemElement`

### DIFF
--- a/circuits/src/generation/memory.rs
+++ b/circuits/src/generation/memory.rs
@@ -184,7 +184,7 @@ pub fn generate_memory_trace<F: RichField>(
     let read_only_addresses: HashSet<F> = memory_init_rows
         .iter()
         .filter(|row| row.filter.is_nonzero() && row.is_writable.is_zero())
-        .map(|row| row.element.address)
+        .map(|row| row.address)
         .collect();
 
     merged_trace.sort_by_key(key);

--- a/circuits/src/generation/memory_zeroinit.rs
+++ b/circuits/src/generation/memory_zeroinit.rs
@@ -13,7 +13,7 @@ pub(crate) fn init_in_program<F: RichField>(program: &Program) -> BTreeSet<u32> 
     generate_memory_init_trace::<F>(program)
         .iter()
         .filter(|row| row.filter.is_one())
-        .filter_map(|row| row.element.address.to_noncanonical_u64().try_into().ok())
+        .filter_map(|row| row.address.to_noncanonical_u64().try_into().ok())
         .collect()
 }
 

--- a/circuits/src/generation/memoryinit.rs
+++ b/circuits/src/generation/memoryinit.rs
@@ -2,7 +2,7 @@ use itertools::{chain, Itertools};
 use mozak_runner::elf::Program;
 use plonky2::hash::hash_types::RichField;
 
-use crate::memoryinit::columns::{MemElement, MemoryInit};
+use crate::memoryinit::columns::MemoryInit;
 use crate::utils::pad_trace_with_default;
 
 /// Generates a memory init ROM trace (ELF + Mozak)
@@ -18,7 +18,7 @@ pub fn generate_memory_init_trace<F: RichField>(program: &Program) -> Vec<Memory
     }
     .collect();
 
-    memory_inits.sort_by_key(|init| init.element.address.to_canonical_u64());
+    memory_inits.sort_by_key(|init| init.address.to_canonical_u64());
 
     let trace = pad_trace_with_default(memory_inits);
     log::trace!("MemoryInit trace {:?}", trace);
@@ -32,7 +32,7 @@ pub fn generate_init_trace<F: RichField, Fn>(program: &Program, f: Fn) -> Vec<Me
 where
     Fn: FnOnce(&Program) -> Vec<MemoryInit<F>>, {
     let mut memory_inits: Vec<MemoryInit<F>> = f(program);
-    memory_inits.sort_by_key(|init| init.element.address.to_canonical_u64());
+    memory_inits.sort_by_key(|init| init.address.to_canonical_u64());
 
     pad_trace_with_default(memory_inits)
 }
@@ -140,10 +140,8 @@ pub fn elf_memory_init<F: RichField>(program: &Program) -> Vec<MemoryInit<F>> {
             mem.iter().map(move |(&addr, &value)| MemoryInit {
                 filter: F::ONE,
                 is_writable,
-                element: MemElement {
-                    address: F::from_canonical_u32(addr),
-                    value: F::from_canonical_u8(value),
-                },
+                address: F::from_canonical_u32(addr),
+                value: F::from_canonical_u8(value),
             })
         })
         .collect_vec()

--- a/circuits/src/memory/columns.rs
+++ b/circuits/src/memory/columns.rs
@@ -58,9 +58,9 @@ impl<F: RichField> From<&MemoryInit<F>> for Option<Memory<F>> {
     fn from(row: &MemoryInit<F>) -> Self {
         row.filter.is_one().then(|| Memory {
             is_writable: row.is_writable,
-            addr: row.element.address,
+            addr: row.address,
             is_init: F::ONE,
-            value: row.element.value,
+            value: row.value,
             clk: F::ONE,
             ..Default::default()
         })

--- a/circuits/src/memoryinit/columns.rs
+++ b/circuits/src/memoryinit/columns.rs
@@ -5,24 +5,14 @@ use crate::cross_table_lookup::ColumnWithTypedInput;
 use crate::linear_combination::Column;
 use crate::stark::mozak_stark::TableWithTypedOutput;
 
-columns_view_impl!(MemElement);
-/// A Memory Slot that has an address and a value
-#[repr(C)]
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
-pub struct MemElement<T> {
-    pub address: T,
-    pub value: T,
-}
-
 columns_view_impl!(MemoryInit);
 make_col_map!(MemoryInit);
 /// A Row of Memory generated from both read-only and read-write memory
 #[repr(C)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct MemoryInit<T> {
-    pub element: MemElement<T>,
-    /// Filters out instructions that are duplicates, i.e., appear more than
-    /// once in the trace.
+    pub address: T,
+    pub value: T,
     pub filter: T,
     /// 1 if this row is a read-write, 0 if this row is read-only
     pub is_writable: T,
@@ -34,12 +24,10 @@ impl<F: RichField> MemoryInit<F> {
     #[must_use]
     pub fn new_readonly((addr, value): (u32, u8)) -> Self {
         Self {
+            address: F::from_canonical_u32(addr),
+            value: F::from_canonical_u8(value),
             filter: F::ONE,
             is_writable: F::ZERO,
-            element: MemElement {
-                address: F::from_canonical_u32(addr),
-                value: F::from_canonical_u8(value),
-            },
         }
     }
 }
@@ -65,9 +53,9 @@ where
     new(
         MemoryInitCtl {
             is_writable: COL_MAP.is_writable,
-            address: COL_MAP.element.address,
+            address: COL_MAP.address,
             clk: ColumnWithTypedInput::constant(1),
-            value: COL_MAP.element.value,
+            value: COL_MAP.value,
         },
         COL_MAP.filter,
     )


### PR DESCRIPTION
`MemElement` is an unnecessary layer of abstraction / indirection.