### PR TITLE
Remove a few unused functions

### DIFF
--- a/circuits/src/cpu/columns.rs
+++ b/circuits/src/cpu/columns.rs
@@ -1,11 +1,5 @@
 use core::ops::{Add, Mul, Sub};
 
-use plonky2::field::extension::Extendable;
-use plonky2::field::types::Field;
-use plonky2::hash::hash_types::RichField;
-use plonky2::iop::ext_target::ExtensionTarget;
-use plonky2::plonk::circuit_builder::CircuitBuilder;
-
 use crate::bitshift::columns::Bitshift;
 use crate::columns_view::{columns_view_impl, make_col_map};
 use crate::cross_table_lookup::{Column, ColumnWithTypedInput};
@@ -227,24 +221,6 @@ where
 
     /// List of opcodes that work with memory.
     pub fn is_mem_op(&self) -> P { self.sb + self.lb + self.sh + self.lh + self.sw + self.lw }
-}
-
-pub fn op1_full_range_extension_target<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    cpu: &CpuState<ExtensionTarget<D>>,
-) -> ExtensionTarget<D> {
-    let shifted_32 = builder.constant_extension(F::Extension::from_canonical_u64(1 << 32));
-    let op1_sign_bit = builder.mul_extension(cpu.op1_sign_bit, shifted_32);
-    builder.sub_extension(cpu.op1_value, op1_sign_bit)
-}
-
-pub fn op2_full_range_extension_target<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    cpu: &CpuState<ExtensionTarget<D>>,
-) -> ExtensionTarget<D> {
-    let shifted_32 = builder.constant_extension(F::Extension::from_canonical_u64(1 << 32));
-    let op2_sign_bit = builder.mul_extension(cpu.op2_sign_bit, shifted_32);
-    builder.sub_extension(cpu.op2_value, op2_sign_bit)
 }
 
 /// Expressions we need to range check

--- a/circuits/src/memory/columns.rs
+++ b/circuits/src/memory/columns.rs
@@ -1,11 +1,8 @@
 use core::ops::Add;
 
-use plonky2::field::extension::Extendable;
 use plonky2::hash::hash_types::RichField;
 use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::hash::poseidon2::Poseidon2Permutation;
-use plonky2::iop::ext_target::ExtensionTarget;
-use plonky2::plonk::circuit_builder::CircuitBuilder;
 
 use crate::columns_view::{columns_view_impl, make_col_map};
 use crate::cross_table_lookup::Column;
@@ -174,14 +171,6 @@ impl<F: RichField> From<&StorageDevice<F>> for Option<Memory<F>> {
 
 impl<T: Copy + Add<Output = T>> Memory<T> {
     pub fn is_executed(&self) -> T { self.is_store + self.is_load + self.is_init }
-}
-
-pub fn is_executed_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    values: &Memory<ExtensionTarget<D>>,
-) -> ExtensionTarget<D> {
-    let tmp = builder.add_extension(values.is_store, values.is_load);
-    builder.add_extension(tmp, values.is_init)
 }
 
 #[must_use]

--- a/circuits/src/stark/utils.rs
+++ b/circuits/src/stark/utils.rs
@@ -1,32 +1,7 @@
-use itertools::{Itertools, MergeBy};
-use plonky2::field::extension::Extendable;
-use plonky2::field::packed::PackedField;
+use itertools::Itertools;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
-use plonky2::hash::hash_types::RichField;
-use plonky2::iop::ext_target::ExtensionTarget;
-use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::util::transpose;
-use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
-
-/// Ensure an expression only takes on values 0 or 1.
-/// This doubles the degree of the provided expression `x`,
-/// so as long as we are targeting degree <= 3,
-/// this should only be called with at most linear expressions.
-pub fn is_binary<P: PackedField>(yield_constr: &mut ConstraintConsumer<P>, x: P) {
-    yield_constr.constraint(x * (P::ONES - x));
-}
-
-pub fn is_binary_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    x: ExtensionTarget<D>,
-    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
-) {
-    let one = builder.one_extension();
-    let x_sub_one = builder.sub_extension(one, x);
-    let x_mul_x_sub_one = builder.mul_extension(x, x_sub_one);
-    yield_constr.constraint(builder, x_mul_x_sub_one);
-}
 
 #[must_use]
 pub fn trace_to_poly_values<F: Field, Grid: IntoIterator<Item = Vec<F>>>(
@@ -55,17 +30,4 @@ pub fn trace_rows_to_poly_values<F: Field, Row: IntoIterator<Item = F>>(
     trace_rows: Vec<Row>,
 ) -> Vec<PolynomialValues<F>> {
     trace_to_poly_values(transpose_trace(trace_rows))
-}
-
-pub fn merge_by_key<Iter, J, F, Key>(
-    iter: Iter,
-    other: J,
-    mut key: F,
-) -> MergeBy<Iter, J::IntoIter, impl FnMut(&Iter::Item, &Iter::Item) -> bool>
-where
-    Iter: Sized + Iterator,
-    J: IntoIterator<Item = Iter::Item>,
-    F: FnMut(&Iter::Item) -> Key,
-    Key: PartialOrd, {
-    iter.merge_by(other, move |x, y| key(x) < key(y))
 }


### PR DESCRIPTION
Mostly thanks to `Expr`-based constraints no longer needing them.