### PR TITLE
Unify panic approach for example for dev and release

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,9 @@ members = [
 ]
 resolver = "2"
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
 codegen-units = 1
 lto = "fat"


### PR DESCRIPTION
We don't actually have the default 'panic = unwind' implemented, so we can't really use it on dev anyway.