### PR TITLE
Fix `test_bundle_tx`

### DIFF
--- a/scripts/test_bundle_tx.sh
+++ b/scripts/test_bundle_tx.sh
@@ -1,19 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 # This script tests transaction bundling.
+
+set -euo pipefail
 
 # Run native executions and build mozakvm binaries
 cd examples/token && cargo run --release \
     --features="native" \
     --bin token-native \
-    --target "$(rustc -vV | grep host | awk '{ print $2; }')" \
-    && cargo build --bin tokenbin --release
+    --target "$(rustc --verbose --version | grep host | awk '{ print $2; }')" &&
+    cargo build --bin tokenbin --release
 
 cd ../wallet && cargo run --release \
     --features="native" \
     --bin wallet-native \
-    --target "$(rustc -vV | grep host | awk '{ print $2; }')" \
-    && cargo build --bin walletbin --release
-
+    --target "$(rustc --verbose --version | grep host | awk '{ print $2; }')" &&
+    cargo build --bin walletbin --release
 
 # Run CLI
 cd ../../


### PR DESCRIPTION
For some reason
https://github.com/0xmozak/mozak-vm/actions/runs/8947735448/job/24622131477?pr=1657
complaints about formatting, even though nothing changed in that PR.
Perhaps it's an update of our shell formatter?

Also make this script bail, if any individual command fails.