### PR TITLE
Fix `plonky2_maybe_rayon` conditional-import problems

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -38,7 +38,6 @@ proptest = "1.4"
 rand = "0.8"
 
 [features]
-default = ["parallel"]
 parallel = ["plonky2/parallel", "starky/parallel", "plonky2_maybe_rayon/parallel", "criterion/rayon"]
 test = []
 timing = ["plonky2/timing", "starky/timing"]

--- a/circuits/src/cross_table_lookup.rs
+++ b/circuits/src/cross_table_lookup.rs
@@ -11,7 +11,8 @@ use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::GenericConfig;
-use plonky2_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+#[allow(clippy::wildcard_imports)]
+use plonky2_maybe_rayon::*;
 use starky::config::StarkConfig;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use starky::evaluation_frame::StarkEvaluationFrame;


### PR DESCRIPTION
Fixes the following error:
```
cargo test --lib stark::batch_prover::tests --manifest-path circuits/Cargo.toml 
   Compiling mozak-circuits v0.1.0 (/Users/saideng/Project/mozak/mozak-vm/circuits)
error[E0432]: unresolved import `plonky2_maybe_rayon::ParallelIterator`
  --> circuits/src/cross_table_lookup.rs:14:45
   |
14 | use plonky2_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
   |                                             ^^^^^^^^^^^^^^^^
   |                                             |
   |                                             no `ParallelIterator` in the root
   |                                             help: a similar name exists in the module: `ParallelIteratorMock`
   |
note: found an item that was configured out
  --> /Users/saideng/.cargo/git/checkouts/plonky2-fb94951b5f6820ea/4a389fb/maybe_rayon/src/lib.rs:11:9
   |
11 |         ParallelIterator,
   |         ^^^^^^^^^^^^^^^^
   = note: the item is gated behind the `parallel` feature

For more information about this error, try `rustc --explain E0432`.
error: could not compile `mozak-circuits` (lib test) due to 1 previous error
```
