### PR TITLE
deps: remove `derive_more` in favour of manual implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,15 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,28 +500,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "derive_more"
-version = "1.0.0-beta.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0-beta.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -915,7 +884,6 @@ dependencies = [
  "arrayvec",
  "bitfield",
  "criterion",
- "derive_more",
  "env_logger",
  "expr",
  "hex",
@@ -1014,7 +982,6 @@ dependencies = [
  "anyhow",
  "bitfield",
  "criterion",
- "derive_more",
  "elf",
  "env_logger",
  "im",
@@ -1925,22 +1892,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unroll"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.1.0"
 anyhow = { version = "1.0", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 bitfield = "0.15"
-derive_more = { version = "1.0.0-beta.6", features = ["full"] }
 expr = { path = "../expr" }
 itertools = "0.12"
 log = "0.4"

--- a/circuits/src/cross_table_lookup.rs
+++ b/circuits/src/cross_table_lookup.rs
@@ -473,7 +473,6 @@ pub mod ctl_utils {
     use std::collections::BTreeMap;
 
     use anyhow::Result;
-    use derive_more::{Deref, DerefMut};
     use plonky2::field::extension::Extendable;
     use plonky2::field::polynomial::PolynomialValues;
     use plonky2::hash::hash_types::RichField;
@@ -482,8 +481,17 @@ pub mod ctl_utils {
     use crate::linear_combination::ColumnSparse;
     use crate::stark::mozak_stark::{MozakStark, Table, TableKind, TableKindArray};
 
-    #[derive(Clone, Debug, Default, Deref, DerefMut)]
+    #[derive(Clone, Debug, Default)]
     struct MultiSet<F>(pub BTreeMap<Vec<u64>, Vec<(TableKind, F)>>);
+
+    impl<F: RichField> std::ops::Deref for MultiSet<F> {
+        type Target = BTreeMap<Vec<u64>, Vec<(TableKind, F)>>;
+
+        fn deref(&self) -> &Self::Target { &self.0 }
+    }
+    impl<F: RichField> std::ops::DerefMut for MultiSet<F> {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    }
 
     impl<F: RichField> MultiSet<F> {
         fn process_row(

--- a/circuits/src/expr.rs
+++ b/circuits/src/expr.rs
@@ -1,6 +1,5 @@
 use std::panic::Location;
 
-use derive_more::Display;
 pub use expr::PureEvaluator;
 use expr::{BinOp, Cached, Evaluator, Expr, UnaOp};
 use plonky2::field::extension::{Extendable, FieldExtension};
@@ -87,7 +86,7 @@ impl<E> Constraint<E> {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Debug, Display)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Debug)]
 enum ConstraintType {
     FirstRow,
     #[default]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.0"
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 bitfield = "0.15"
-derive_more = { version = "1.0.0-beta.6", features = ["full"] }
 elf = { version = "0.7" }
 env_logger = { version = "0.11" }
 im = "15.1"

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
-use derive_more::{Deref, IntoIterator};
 use im::hashmap::HashMap;
 use itertools::{chain, izip};
 use mozak_sdk::core::ecall;
@@ -17,8 +16,14 @@ use crate::vm::{step, ExecutionRecord};
 /// Executable code of the ELF
 ///
 /// A wrapper of a map from pc to [Instruction]
-#[derive(Clone, Debug, Default, Deref, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Code(pub HashMap<u32, Result<Instruction, DecodingError>>);
+
+impl std::ops::Deref for Code {
+    type Target = HashMap<u32, Result<Instruction, DecodingError>>;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
 
 impl Code {
     /// Get [Instruction] given `pc`

--- a/runner/src/ecall.rs
+++ b/runner/src/ecall.rs
@@ -28,7 +28,7 @@ impl<F: RichField> State<F> {
     fn ecall_read(mut self, op: StorageDeviceOpcode) -> (Aux<F>, Self) {
         let buffer_start = self.get_register_value(REG_A1);
         let num_bytes_requested = self.get_register_value(REG_A2);
-        log::trace!("ECALL {}", op);
+        log::trace!("ECALL {:?}", op);
 
         let data = match op {
             StorageDeviceOpcode::StorePublic => read_bytes(

--- a/runner/src/elf.rs
+++ b/runner/src/elf.rs
@@ -2,7 +2,6 @@ use std::cmp::{max, min};
 use std::iter::repeat;
 
 use anyhow::{anyhow, ensure, Result};
-use derive_more::{Deref, DerefMut, IntoIterator};
 use elf::endian::LittleEndian;
 use elf::file::Class;
 use elf::segment::{ProgramHeader, SegmentTable};
@@ -34,10 +33,14 @@ pub struct Program {
 /// Memory of RISC-V Program
 ///
 /// A wrapper around a map from a 32-bit address to a byte of memory
-#[derive(
-    Clone, Debug, Default, Deref, Serialize, Deserialize, DerefMut, IntoIterator, PartialEq,
-)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Data(pub HashMap<u32, u8>);
+
+impl std::ops::Deref for Data {
+    type Target = HashMap<u32, u8>;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
 
 impl From<HashMap<u32, u32>> for Program {
     fn from(image: HashMap<u32, u32>) -> Self {

--- a/runner/src/instruction.rs
+++ b/runner/src/instruction.rs
@@ -1,5 +1,4 @@
 //! RV32I Base Integer Instructions + RV32M Multiply Extension
-use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
 /// Arguments of a RISC-V instruction
@@ -16,7 +15,7 @@ pub struct Args {
 }
 
 /// Operands of RV32I + RV32M
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Display, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum Op {
     // RV32I Base Integer Instructions

--- a/runner/src/state.rs
+++ b/runner/src/state.rs
@@ -3,7 +3,6 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use anyhow::{anyhow, Result};
-use derive_more::{Deref, Display};
 use im::hashmap::HashMap;
 use im::HashSet;
 use log::trace;
@@ -16,8 +15,14 @@ use crate::elf::{Data, Program};
 use crate::instruction::{Args, DecodingError, Instruction};
 use crate::poseidon2;
 
-#[derive(Debug, Clone, Deref)]
+#[derive(Debug, Clone)]
 pub struct CommitmentTape(pub [u8; DIGEST_BYTES]);
+
+impl std::ops::Deref for CommitmentTape {
+    type Target = [u8; DIGEST_BYTES];
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
 
 pub fn read_bytes(buf: &[u8], index: &mut usize, num_bytes: usize) -> Vec<u8> {
     let remaining_len = buf.len() - *index;
@@ -97,9 +102,8 @@ impl StateMemory {
     }
 }
 
-#[derive(Clone, Debug, Deref, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StorageDeviceTape {
-    #[deref]
     pub data: Rc<[u8]>,
     pub read_index: usize,
 }
@@ -174,7 +178,7 @@ pub struct MemEntry {
     pub raw_value: u32,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Display, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[repr(u8)]
 pub enum StorageDeviceOpcode {
     #[default]

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -317,7 +317,7 @@ pub fn step<F: RichField>(
         {
             let count: u32 = count.try_into().unwrap();
             let percentage = 100_f64 * f64::from(count) / f64::from(total);
-            println!("{percentage:6.2?}%\t{count:10} {op}");
+            println!("{percentage:6.2?}%\t{count:10} {op:?}");
         }
     }
     Ok(ExecutionRecord::<F> {


### PR DESCRIPTION
We are only using derive_more for really `Deref`, `DerefMut`, and `Display`, all of which are trivial to manually implement. So this PR does the following:

- removes `derive_more` as a dependency,
- manually adds implementations of `Deref` and `DerefMut` where necessary,
- change items which were using `Display` to use debug formatting `{:?}`

This allows us to slim down our dependency tree + save on compilation time since `derive-more_impl` is quite expensive to compile.

For some real data:

On `main`:

```console
$ cargo build --timings
Finished `dev` profile [optimized + debuginfo] target(s) in 2m 06s
```

This branch:
```console
$ cargo build --timings
Finished `dev` profile [optimized + debuginfo] target(s) in 1m 56s
```

According to `--timings`, we're spending about 16.1s to build a fully featured `derive_more-impl`:

<img width="1181" alt="Screenshot 2024-05-13 at 12 43 42 PM" src="https://github.com/0xmozak/mozak-vm/assets/25565268/0766a852-04a5-4980-bad8-c7691ea462a3">
