### PR TITLE
fix: add support for empty event roots via dummy proofs

### DIFF
--- a/recproofs/src/circuits/verify_block/core.rs
+++ b/recproofs/src/circuits/verify_block/core.rs
@@ -112,7 +112,7 @@ impl SubCircuitInputs {
         )
         .common;
 
-        let dummy = dummy_circuit::<_, C, D>(&common, |builder| self.register_inputs(builder));
+        let dummy = dummy_circuit::<C, D>(&common, |builder| self.register_inputs(builder));
 
         let prev_proof = builder.add_virtual_proof_with_pis(&common);
 

--- a/recproofs/src/circuits/verify_program/core.rs
+++ b/recproofs/src/circuits/verify_program/core.rs
@@ -1,18 +1,20 @@
 use itertools::chain;
 use plonky2::field::extension::Extendable;
+use plonky2::field::types::Field;
 use plonky2::hash::hash_types::{HashOutTarget, RichField};
 use plonky2::hash::poseidon2::Poseidon2Hash;
 use plonky2::iop::target::{BoolTarget, Target};
-use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::{
-    CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
+    CircuitData, CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
 };
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
 
 use crate::circuits::build_event_root;
 use crate::indices::{ArrayTargetIndex, BoolTargetIndex, HashOutTargetIndex, TargetIndex};
+use crate::{dummy_circuit, select_verifier};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct ProgramPublicIndices {
@@ -139,38 +141,73 @@ impl<const D: usize> ProgramVerifierSubCircuit<D> {
     }
 }
 
-pub struct EventRootVerifierTargets<const D: usize> {
+pub struct EventRootVerifierTargets<C: GenericConfig<D>, const D: usize> {
     /// The event root proof
     pub event_root_proof: ProofWithPublicInputsTarget<D>,
 
     /// The event owner
     pub event_owner: [Target; 4],
 
+    /// If events are present or not
+    pub events_present: BoolTarget,
+
     /// The event root (rp_hash)
     pub event_root: HashOutTarget,
 
     /// The event root (vm hash)
     pub vm_event_root: HashOutTarget,
+
+    /// The circuit for absent event proofs
+    zero_circuit: CircuitData<C::F, C, D>,
+
+    /// The event owner for absent event proofs
+    zero_circuit_event_owner: [Target; 4],
 }
 
-pub struct EventRootVerifierSubCircuit<const D: usize> {
-    pub targets: EventRootVerifierTargets<D>,
+pub struct EventRootVerifierSubCircuit<C: GenericConfig<D>, const D: usize> {
+    pub targets: EventRootVerifierTargets<C, D>,
 }
 
-impl<const D: usize> EventRootVerifierTargets<D> {
+impl<C: GenericConfig<D>, const D: usize> EventRootVerifierTargets<C, D> {
     #[must_use]
-    pub fn build_targets<F, C>(
-        builder: &mut CircuitBuilder<F, D>,
-        event_root_circuit: &build_event_root::BranchCircuit<F, C, D>,
+    pub fn build_targets(
+        builder: &mut CircuitBuilder<C::F, D>,
+        event_root_circuit: &build_event_root::BranchCircuit<C::F, C, D>,
     ) -> Self
     where
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<F>, {
+        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<C::F>, {
         let circuit = &event_root_circuit.circuit;
-        let event_root_proof = builder.add_virtual_proof_with_pis(&circuit.common);
-        let verifier = builder.constant_verifier_data(&circuit.verifier_only);
 
+        let zero_circuit_event_owner = event_root_circuit.event_owner.targets.inputs.values;
+        let zero_circuit = dummy_circuit::<C, D>(&circuit.common, |builder| {
+            let hash = event_root_circuit
+                .hash
+                .targets
+                .inputs
+                .unpruned_hash
+                .elements;
+            let vm_hash = event_root_circuit
+                .vm_hash
+                .targets
+                .inputs
+                .unpruned_hash
+                .elements;
+            builder.register_public_inputs(&zero_circuit_event_owner);
+            builder.register_public_inputs(&hash);
+            builder.register_public_inputs(&vm_hash);
+            for v in hash {
+                builder.assert_zero(v);
+            }
+            for v in vm_hash {
+                builder.assert_zero(v);
+            }
+        });
+        let event_root_proof = builder.add_virtual_proof_with_pis(&circuit.common);
+        let real_verifier = builder.constant_verifier_data(&circuit.verifier_only);
+        let zero_verifier = builder.constant_verifier_data(&zero_circuit.verifier_only);
+        let events_present = builder.add_virtual_bool_target_safe();
+
+        let verifier = select_verifier(builder, events_present, &real_verifier, &zero_verifier);
         builder.verify_proof::<C>(&event_root_proof, &verifier, &circuit.common);
 
         let event_owner = event_root_circuit
@@ -191,29 +228,48 @@ impl<const D: usize> EventRootVerifierTargets<D> {
 
         Self {
             event_root_proof,
+            events_present,
             event_owner,
             event_root,
             vm_event_root,
+            zero_circuit,
+            zero_circuit_event_owner,
         }
     }
 }
 
-impl<const D: usize> EventRootVerifierTargets<D> {
+impl<C: GenericConfig<D>, const D: usize> EventRootVerifierTargets<C, D> {
     #[must_use]
-    pub fn build(self, _public_inputs: &[Target]) -> EventRootVerifierSubCircuit<D> {
+    pub fn build(self, _public_inputs: &[Target]) -> EventRootVerifierSubCircuit<C, D> {
         EventRootVerifierSubCircuit { targets: self }
     }
 }
 
-impl<const D: usize> EventRootVerifierSubCircuit<D> {
-    pub fn set_witness<F, C>(
+impl<C: GenericConfig<D>, const D: usize> EventRootVerifierSubCircuit<C, D> {
+    pub fn set_witness(
         &self,
-        inputs: &mut PartialWitness<F>,
-        event_root_proof: &ProofWithPublicInputs<F, C, D>,
+        inputs: &mut PartialWitness<C::F>,
+        event_root_proof: Result<&ProofWithPublicInputs<C::F, C, D>, [C::F; 4]>,
     ) where
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<F>, {
+        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<C::F>, {
+        let storage;
+        let event_root_proof = match event_root_proof {
+            Ok(proof) => proof,
+            Err(owner) => {
+                let mut dummy_inputs = PartialWitness::new();
+                dummy_inputs.set_target_arr(&self.targets.zero_circuit_event_owner, &owner);
+                // Zero out all other inputs
+                for i in 0..self.targets.zero_circuit.common.num_public_inputs {
+                    let target = self.targets.zero_circuit.prover_only.public_inputs[i];
+                    if dummy_inputs.try_get_target(target).is_none() {
+                        dummy_inputs.set_target(target, <C::F>::ZERO);
+                    }
+                }
+                storage = self.targets.zero_circuit.prove(dummy_inputs).unwrap();
+                &storage
+            }
+        };
+
         inputs.set_proof_with_pis_target(&self.targets.event_root_proof, event_root_proof);
     }
 }

--- a/recproofs/src/lib.rs
+++ b/recproofs/src/lib.rs
@@ -159,10 +159,10 @@ impl EventFlags {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Event<F> {
-    owner: [F; 4],
-    ty: EventType,
-    address: u64,
-    value: [F; 4],
+    pub owner: [F; 4],
+    pub ty: EventType,
+    pub address: u64,
+    pub value: [F; 4],
 }
 
 impl<F: RichField> Event<F> {
@@ -591,13 +591,13 @@ where
 
 /// Generate a circuit matching a given `CommonCircuitData`.
 #[must_use]
-pub fn dummy_circuit<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
-    common_data: &CommonCircuitData<F, D>,
-    register_public_inputs: impl FnOnce(&mut CircuitBuilder<F, D>),
-) -> CircuitData<F, C, D> {
+pub fn dummy_circuit<C: GenericConfig<D>, const D: usize>(
+    common_data: &CommonCircuitData<C::F, D>,
+    register_public_inputs: impl FnOnce(&mut CircuitBuilder<C::F, D>),
+) -> CircuitData<C::F, C, D> {
     let config = common_data.config.clone();
 
-    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let mut builder = CircuitBuilder::<C::F, D>::new(config);
     // Build up enough wires to cover all our inputs
     for _ in 0..common_data.num_public_inputs {
         let _ = builder.add_virtual_target();


### PR DESCRIPTION
Also some minor refactors, like re-ordering params to be the same, and splitting `prove` into two versions to avoid having `None` require unused generics.