### PR TITLE
fix: dummy event proof registration order

### DIFF
--- a/recproofs/src/circuits/verify_program.rs
+++ b/recproofs/src/circuits/verify_program.rs
@@ -656,8 +656,8 @@ pub mod test {
         )
     }
 
-    #[tested_fixture::tested_fixture(PM_EMPTY_EVENT_LEAF_PROOF: LeafProof<F, C, D>)]
-    fn verify_empty_leaf() -> Result<LeafProof<F, C, D>> {
+    #[test]
+    fn verify_empty_leaf_pm() -> Result<()> {
         let program_proof = PROGRAM_M
             .prove(None, NON_ZERO_VALUES[0], CAST_ROOT[0])
             .expect("shouldn't fail");
@@ -673,8 +673,29 @@ pub mod test {
             Err(PROGRAM_M.program_hash_val),
         )?;
         assert_proof(&proof, None, PROGRAM_M.program_hash_val);
-        LEAF.verify(proof.clone())?;
-        Ok(proof)
+        LEAF.verify(proof)?;
+        Ok(())
+    }
+
+    #[test]
+    fn verify_empty_leaf_p0() -> Result<()> {
+        let program_proof = PROGRAM_0
+            .prove(None, NON_ZERO_VALUES[0], CAST_ROOT[0])
+            .expect("shouldn't fail");
+        PROGRAM_0
+            .circuit
+            .verify(program_proof.clone())
+            .expect("shouldn't fail");
+
+        let proof = LEAF.prove(
+            &BRANCH,
+            &PROGRAM_0.circuit.verifier_only,
+            &program_proof,
+            Err(PROGRAM_0.program_hash_val),
+        )?;
+        assert_proof(&proof, None, PROGRAM_0.program_hash_val);
+        LEAF.verify(proof)?;
+        Ok(())
     }
 
     #[test]

--- a/recproofs/src/circuits/verify_program/core.rs
+++ b/recproofs/src/circuits/verify_program/core.rs
@@ -192,9 +192,7 @@ impl<C: GenericConfig<D>, const D: usize> EventRootVerifierTargets<C, D> {
                 .inputs
                 .unpruned_hash
                 .elements;
-            builder.register_public_inputs(&zero_circuit_event_owner);
-            builder.register_public_inputs(&hash);
-            builder.register_public_inputs(&vm_hash);
+            builder.register_public_inputs(&circuit.prover_only.public_inputs);
             for v in hash {
                 builder.assert_zero(v);
             }


### PR DESCRIPTION
When doing public input registration, both order and target ids matter. Getting this wrong in the build event dummy circuit resulted in the mix up of event owner and root hash.

The `verify_empty_leaf` test passed because both are zero (`PROGRAM_M` has an ID of all zeros), but this functionality failed for all other programs, meaning only this special zero program was allowed to emit no events, any other program attempting to emit no events would fail.

The fix is just to copy all target registrations from the real event circuit in order.

Also added a new regression test to catch this (and removed test result caching from the original test as it was unused).