### PR TITLE
feat: generic address path

### DIFF
--- a/node/src/block_proposer.rs
+++ b/node/src/block_proposer.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::ops::{BitAnd, BitAndAssign, Shl, Sub};
+
 pub mod state;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,32 +26,55 @@ impl Address {
 /// The remaining bits of an address to be consumed as one traverses down the
 /// tree towards a leaf.
 #[derive(Debug, Clone, Copy)]
-pub struct AddressPath {
+pub struct AddressPath<T = u64> {
     /// One less than the number of bits remaining in `addr`
     ///
     /// So `height == 0` means 1 bit remaining, `1` means 2 bits remaining.
     ///
     /// This means that `1 << height` will mask off the MSB.
     height: usize,
-    addr: u64,
+    addr: T,
 }
 
-impl AddressPath {
-    fn next(mut self) -> (Option<Self>, Dir) {
-        // look at the MSB for the current direction
-        let msb_mask = 1 << self.height;
+impl<T> AddressPath<T>
+where
+    T: Copy
+        + From<bool>
+        + Shl<usize, Output = T>
+        + BitAnd<T, Output = T>
+        + PartialEq
+        + fmt::Debug
+        + Sub<T, Output = T>
+        + BitAndAssign,
+{
+    pub fn path(addr: T, bits: usize) -> Option<Self> {
+        (bits != 0).then_some(Self {
+            height: bits - 1,
+            addr,
+        })
+    }
 
-        let dir = if self.addr & msb_mask != 0 {
-            Dir::Right
-        } else {
+    /// Returns `true` if all remaining directions are `Dir::Left`
+    pub fn is_zero(self) -> bool { self.addr == T::from(false) }
+
+    pub fn next(mut self) -> (Option<Self>, Dir) {
+        let zero = T::from(false);
+        let one = T::from(true);
+
+        // look at the MSB for the current direction
+        let msb_mask = one << self.height;
+
+        let dir = if self.addr & msb_mask == zero {
             Dir::Left
+        } else {
+            Dir::Right
         };
 
         // Pop the MSB
-        self.addr &= msb_mask - 1;
+        self.addr &= msb_mask - one;
 
         if self.height == 0 {
-            debug_assert_eq!(self.addr, 0);
+            debug_assert_eq!(self.addr, zero);
             (None, dir)
         } else {
             self.height -= 1;


### PR DESCRIPTION
Make `AddressPath` generic so it can support different integer types.

Also add a new constructor (`path`) and a helper (`is_zero`) for use in the tx driver (#1713).