### PR TITLE
chore: rename SDK Event discriminants

### DIFF
--- a/node/src/block_proposer/transactions.rs
+++ b/node/src/block_proposer/transactions.rs
@@ -549,8 +549,8 @@ fn convert_event_type(ty: SdkEventType) -> ProofEventType {
         SdkEventType::Write => ProofEventType::Write,
         SdkEventType::Ensure => ProofEventType::Ensure,
         SdkEventType::Read => ProofEventType::Read,
-        SdkEventType::Create => ProofEventType::GiveOwner,
-        SdkEventType::Delete => ProofEventType::TakeOwner,
+        SdkEventType::GiveOwner => ProofEventType::GiveOwner,
+        SdkEventType::TakeOwner => ProofEventType::TakeOwner,
     }
 }
 

--- a/sdk/src/common/types/event.rs
+++ b/sdk/src/common/types/event.rs
@@ -26,8 +26,8 @@ pub enum EventType {
     Write = 0,
     Ensure,
     Read,
-    Create,
-    Delete,
+    GiveOwner,
+    TakeOwner,
 }
 
 impl Default for EventType {


### PR DESCRIPTION
We will still need to add one for credits later, but that's not a blocker for anything